### PR TITLE
Some bug fixes (Paged, SCOPE_IDENTITY())

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -299,7 +299,7 @@ namespace Massive {
                 var cmd = CreateInsertCommand(o);
                 cmd.Connection = conn;
                 cmd.ExecuteNonQuery();
-                cmd.CommandText = "SELECT @@IDENTITY as newID";
+                cmd.CommandText = "SELECT SCOPE_IDENTITY() as newID";
                 result = cmd.ExecuteScalar();
             }
             return result;


### PR DESCRIPTION
Paged: It was throwing invalid statement exceptions because the statement turned out to be `SELECT x FROM xWHERE`.
Insert: Using `SCOPE_IDENTITY()` instead of `@@Identity`. (robconery/massive#18)
