### PR TITLE
Whitelist, object-based column specification, refactor, and object-based where

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Massive is a Single File Database Lover. Move over Bacon - Taste is got a new fr
 
 
 I'm sharing this with the world because we need another way to access data - don't you think? Truthfully - I wanted to see if I could flex the C# 4 stuff and
-run up data access with a single file. This is ready to roll and weighs in at a lovely 264 lines of code. Some of which is comments.
+run up data access with a single file. This is ready to roll and weighs in at a lovely 266 lines of code. Some of which is comments.
 
 How To Install It?
 ------------------


### PR DESCRIPTION
This is the same as my immensely large pull request but boiled down into 5 bite-sized chunks (I can only guarantee the 1st, 2nd and 5th commits work, the middle two probably work; they at least compile). Backwards compatibility was attempted but may have failed because of the route taken to get here.

Whitelist:
This allows you to pass a string, object, Type to define the columns that are to be updated.  Pretty simple.  Had to do some weird naming to allow backwards compatibility with Save.

Object-based columns:
using the work done in Whitelist allows you to specify columns to retrieve using a string, object, or Type.  Handy for retrieving only the columns your POCO needs.

Refactor:
Removed 90 lines of code with some aggressive refactoring and line collapsing.  I may have gone overboard. :)

Object-based where:
This allows you to specify the where as a string, object, or dictionary.  Key is column and value is the "=" value.  Only supports equality but still handy for simple scoping.

Cheers!
