### PR TITLE
Marked DynamicModel as Abstract

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -87,7 +87,7 @@ namespace Massive {
     /// <summary>
     /// A class that wraps your database table in Dynamic Funtime
     /// </summary>
-    public  class DynamicModel {
+    public abstract class DynamicModel {
         DbProviderFactory _factory;
         string _connectionString;
 


### PR DESCRIPTION
It seems to me that users of massive shouldn't ever create instances of DynamicModel, so I marked it as abstract.
