### PR TITLE
Fix to ToExpando() to work with any subclass of NameValueCollection (ex: FormCollection from MVC)

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -66,7 +66,7 @@ namespace Massive {
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
             if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
-            if (o.GetType() == typeof(NameValueCollection)) {
+            if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection)))
                 var nv = (NameValueCollection)o;
                 nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(i => d.Add(i));
             } else {


### PR DESCRIPTION
Added a check for IsSubclassOf(typeof(NameValueCollection) inside the ToExpando() method.
Now you can pass any subclass of NameValueCollection and it will work.
