### PR TITLE
Whitelist and object-based columns

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Massive is a Single File Database Lover. Move over Bacon - Taste is got a new fr
 
 
 I'm sharing this with the world because we need another way to access data - don't you think? Truthfully - I wanted to see if I could flex the C# 4 stuff and
-run up data access with a single file. This is ready to roll and weighs in at a lovely 349 lines of code. Most of which is comments.
+run up data access with a single file. This is ready to roll and weighs in at a lovely 346 lines of code. Most of which is comments.
 
 How To Install It?
 ------------------


### PR DESCRIPTION
One more attempt to try to contribute back my changes.

This adds the ability to specify a whitelist of columns to insert or update using an object, Type, or Dictionary.  It also allows you to specify the columns to be returned in the same manner.  The existing string-based option still exists.

This is the bare functionality.  No attempts to clean up improper uses of casts or unused parameters in format strings.  No removing redundant type specifiers or object initializers.  It is a sea of Resharper yellow.  No refactoring or reorganizing.  Enumerables are converted to arrays so that they can immediately be used as enumerables again.  And since I know what a a sore point it was for you last time, I guarantee this does not compile*.

However it does work in my test suite (a web application I'm building).  It contains useful functionality, and attempts to retain backwards compatibility.  If it's not useful for you, don't take it.

*Just kidding, it compiles.
