### PR TITLE
Massive only inserts first 4k of text

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -41,7 +41,7 @@ namespace Massive {
                 }
                 //from DataChomp
                 if (item.GetType() == typeof(string))
-                    p.Size = 4000;
+                    p.Size = 4000 > ((string)item).Length ? 4000 : ((string)item).Length;
             }
             cmd.Parameters.Add(p);
         }


### PR DESCRIPTION
I've run into an issue with inserting large amounts of text (greater than 4000 characters) with Massive. Massive sets the length for all string parameters to 4000 without checking to see if their length is longer. I added a check for this and have posted a link to a console app I wrote to test the bug and the fix as well.

To run the test app, create a db on a local sqlexpress install named "BlogExample", then run the console app.

http://dl.dropbox.com/u/6291954/MassiveTest.zip
