### PR TITLE
Added support for param values to be longer than 4000 characters

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -40,8 +40,11 @@ namespace Massive {
                     p.Value = item;
                 }
                 //from DataChomp
+				// jared: added a check for the length here
+				// if the length is greater than 4000 then it is
+				// assumed we are saving a ntext or nvarchar(max)
                 if (item.GetType() == typeof(string))
-                    p.Size = 4000 > ((string)item).Length ? 4000 : ((string)item).Length;
+                    p.Size = ((string)item).Length > 4000 ? -1 : 4000;
             }
             cmd.Parameters.Add(p);
         }


### PR DESCRIPTION
I was pretty surprised when I found that I couldn't insert more than 4000 characters using Massive. I submitted a patch yesterday but I closed it after DataChomp pointed out that it broke query plan caching.

The patch I have here checks the length of the value in the param and if the length is greater than 4000 it sets the length to -1 assuming that the param is going against a ntext/nvarchar(max) column.
