### PR TITLE
Allow ColumnPrefix to be defined for Rails-y querying

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -223,6 +223,7 @@ namespace Massive {
             return result;
         }
         public virtual string TableName { get; set; }
+        public virtual string ColumnPrefix { get; set; }
         /// <summary>
         /// Creates a command for use with transactions - internal stuff mostly, but here for you to play with
         /// </summary>
@@ -388,7 +389,7 @@ namespace Massive {
             var counter = 0;
             for (int i = 1; i < stems.Length; i++) {
                 if (stems[i].Trim().ToLower() != "and") {
-                    sb.Add(stems[i] + "=@" + counter);
+                    sb.Add((!string.IsNullOrEmpty(ColumnPrefix) ? ColumnPrefix : "") + stems[i] + "=@" + counter);
                     counter++;
                 }
             }


### PR DESCRIPTION
This change allows you to use the Rails-y methods like "FindBy_ID" more easily if you use column prefixes for your database column names. It also allows column prefixes with underscores in them like "Category_ID" to still be used in Rails-y fashion.

To use, in your table wrap class constructor, just set the ColumnPrefix property to the prefix being used for the table you're wrapping. For instance, if you have a Categories table with column names like `"Cat_ID"` and `"Cat_Name"`, set ColumnPrefix to `"Cat_"`, then you can use Rails-y `categories.FindBy_ID` and `categories.FindBy_Name` methods.
