### PR TITLE
Default provider name does not work for SqlCE 4

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -100,6 +100,10 @@ namespace Massive {
             TableName = tableName == "" ? this.GetType().Name : tableName;
             PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
             var _providerName = "System.Data.SqlClient";
+            if(!string.IsNullOrEmpty(ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName))
+            {
+               _providerName = ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName;
+            }
             _factory = DbProviderFactories.GetFactory(_providerName);
             ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
         }


### PR DESCRIPTION
If SqlCE 4 is being used the System.Data.SqlClient provider name does not work. This change will allow Massive to read the provider name from the config file.
