### PR TITLE
corrections for batch updates to work / treating enum values as strings in DB, and making All() remember it was enumerated

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -10,47 +10,37 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Data.SqlClient;
 
-namespace Massive
-{
-    public static class ObjectExtensions
-    {
+namespace Massive {
+    public static class ObjectExtensions {
         /// <summary>
         /// Extension method for adding in a bunch of parameters
         /// </summary>
-        public static void AddParams(this DbCommand cmd, params object[] args)
-        {
-            foreach (var item in args)
-            {
+        public static void AddParams(this DbCommand cmd, params object[] args) {
+            foreach (var item in args) {
                 AddParam(cmd, item);
             }
         }
         /// <summary>
         /// Extension for adding single parameter
         /// </summary>
-        public static void AddParam(this DbCommand cmd, object item)
-        {
+        public static void AddParam(this DbCommand cmd, object item) {
             var p = cmd.CreateParameter();
             p.ParameterName = string.Format("@{0}", cmd.Parameters.Count);
-            if (item == null)
-            {
+            if (item == null) {
                 p.Value = DBNull.Value;
             }
-            else
-            {
+            else {
                 Type type = item.GetType();
-                if (type == typeof(Guid)||type.IsEnum)
-                {
+                if (type == typeof(Guid) || type.IsEnum) {
                     p.Value = item.ToString();
                     p.DbType = DbType.String;
                     p.Size = 4000;
                 }
-                else if (type == typeof(ExpandoObject))
-                {
+                else if (type == typeof(ExpandoObject)) {
                     var d = (IDictionary<string, object>)item;
                     p.Value = d.Values.FirstOrDefault();
                 }
-                else
-                {
+                else {
                     p.Value = item;
                 }
                 if (type == typeof(string))
@@ -61,17 +51,14 @@ namespace Massive
         /// <summary>
         /// Turns an IDataReader to a Dynamic list of things
         /// </summary>
-        public static List<dynamic> ToExpandoList(this IDataReader rdr)
-        {
+        public static List<dynamic> ToExpandoList(this IDataReader rdr) {
             var result = new List<dynamic>();
-            while (rdr.Read())
-            {
+            while (rdr.Read()) {
                 result.Add(rdr.RecordToExpando());
             }
             return result;
         }
-        public static dynamic RecordToExpando(this IDataReader rdr)
-        {
+        public static dynamic RecordToExpando(this IDataReader rdr) {
             dynamic e = new ExpandoObject();
             var d = e as IDictionary<string, object>;
             for (int i = 0; i < rdr.FieldCount; i++)
@@ -81,21 +68,17 @@ namespace Massive
         /// <summary>
         /// Turns the object into an ExpandoObject
         /// </summary>
-        public static dynamic ToExpando(this object o)
-        {
+        public static dynamic ToExpando(this object o) {
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
             if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
-            if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection)))
-            {
+            if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection))) {
                 var nv = (NameValueCollection)o;
                 nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(i => d.Add(i));
             }
-            else
-            {
+            else {
                 var props = o.GetType().GetProperties();
-                foreach (var item in props)
-                {
+                foreach (var item in props) {
                     d.Add(item.Name, item.GetValue(o, null));
                 }
             }
@@ -104,25 +87,21 @@ namespace Massive
         /// <summary>
         /// Turns the object into a Dictionary
         /// </summary>
-        public static IDictionary<string, object> ToDictionary(this object thingy)
-        {
+        public static IDictionary<string, object> ToDictionary(this object thingy) {
             return (IDictionary<string, object>)thingy.ToExpando();
         }
     }
     /// <summary>
     /// A class that wraps your database table in Dynamic Funtime
     /// </summary>
-    public class DynamicModel : DynamicObject
-    {
+    public class DynamicModel : DynamicObject {
         DbProviderFactory _factory;
         string ConnectionString;
-        public static DynamicModel Open(string connectionStringName)
-        {
+        public static DynamicModel Open(string connectionStringName) {
             dynamic dm = new DynamicModel(connectionStringName);
             return dm;
         }
-        public DynamicModel(string connectionStringName, string tableName = "", string primaryKeyField = "")
-        {
+        public DynamicModel(string connectionStringName, string tableName = "", string primaryKeyField = "") {
             TableName = tableName == "" ? this.GetType().Name : tableName;
             PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
             var _providerName = "System.Data.SqlClient";
@@ -133,21 +112,17 @@ namespace Massive
         /// <summary>
         /// Creates a new Expando from a Form POST - white listed against the columns in the DB
         /// </summary>
-        public dynamic CreateFrom(NameValueCollection coll)
-        {
+        public dynamic CreateFrom(NameValueCollection coll) {
             dynamic result = new ExpandoObject();
             var dc = (IDictionary<string, object>)result;
             var schema = Schema;
             //loop the collection, setting only what's in the Schema
-            foreach (var item in coll.Keys)
-            {
+            foreach (var item in coll.Keys) {
                 var exists = schema.Any(x => x.COLUMN_NAME.ToLower() == item.ToString().ToLower());
-                if (exists)
-                {
+                if (exists) {
                     var key = item.ToString();
                     var val = coll[key];
-                    if (!String.IsNullOrEmpty(val))
-                    {
+                    if (!String.IsNullOrEmpty(val)) {
                         //what to do here? If it's empty... set it to NULL?
                         //if it's a string value - let it go through if it's NULLABLE?
                         //Empty? WTF?
@@ -160,24 +135,19 @@ namespace Massive
         /// <summary>
         /// Gets a default value for the column
         /// </summary>
-        public dynamic DefaultValue(dynamic column)
-        {
+        public dynamic DefaultValue(dynamic column) {
             dynamic result = null;
             string def = column.COLUMN_DEFAULT;
-            if (String.IsNullOrEmpty(def))
-            {
+            if (String.IsNullOrEmpty(def)) {
                 result = null;
             }
-            else if (def == "getdate()" || def == "(getdate())")
-            {
+            else if (def == "getdate()" || def == "(getdate())") {
                 result = DateTime.Now.ToShortDateString();
             }
-            else if (def == "newid()")
-            {
+            else if (def == "newid()") {
                 result = Guid.NewGuid().ToString();
             }
-            else
-            {
+            else {
                 result = def.Replace("(", "").Replace(")", "");
             }
             return result;
@@ -185,14 +155,11 @@ namespace Massive
         /// <summary>
         /// Creates an empty Expando set with defaults from the DB
         /// </summary>
-        public dynamic Prototype
-        {
-            get
-            {
+        public dynamic Prototype {
+            get {
                 dynamic result = new ExpandoObject();
                 var schema = Schema;
-                foreach (dynamic column in schema)
-                {
+                foreach (dynamic column in schema) {
                     var dc = (IDictionary<string, object>)result;
                     dc.Add(column.COLUMN_NAME, DefaultValue(column));
                 }
@@ -204,10 +171,8 @@ namespace Massive
         /// List out all the schema bits for use with ... whatever
         /// </summary>
         IEnumerable<dynamic> _schema;
-        public IEnumerable<dynamic> Schema
-        {
-            get
-            {
+        public IEnumerable<dynamic> Schema {
+            get {
                 if (_schema == null)
                     _schema = Query("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @0", TableName);
                 return _schema;
@@ -217,13 +182,10 @@ namespace Massive
         /// <summary>
         /// Enumerates the reader yielding the result - thanks to Jeroen Haegebaert
         /// </summary>
-        public virtual IEnumerable<dynamic> Query(string sql, params object[] args)
-        {
-            using (var conn = OpenConnection())
-            {
+        public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
+            using (var conn = OpenConnection()) {
                 var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read())
-                {
+                while (rdr.Read()) {
                     yield return rdr.RecordToExpando(); ;
                 }
             }
@@ -231,10 +193,8 @@ namespace Massive
         /// <summary>
         /// Executes the reader using SQL async API - thanks to Damian Edwards
         /// </summary>
-        public void QueryAsync(string sql, Action<List<dynamic>> callback, params object[] args)
-        {
-            using (var conn = new SqlConnection(ConnectionString))
-            {
+        public void QueryAsync(string sql, Action<List<dynamic>> callback, params object[] args) {
+            using (var conn = new SqlConnection(ConnectionString)) {
                 var cmd = new SqlCommand(sql, conn);
                 cmd.AddParams(args);
                 conn.Open();
@@ -245,12 +205,9 @@ namespace Massive
             }
         }
 
-        public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args)
-        {
-            using (var rdr = CreateCommand(sql, connection, args).ExecuteReader())
-            {
-                while (rdr.Read())
-                {
+        public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args) {
+            using (var rdr = CreateCommand(sql, connection, args).ExecuteReader()) {
+                while (rdr.Read()) {
                     yield return rdr.RecordToExpando(); ;
                 }
             }
@@ -258,11 +215,9 @@ namespace Massive
         /// <summary>
         /// Returns a single result
         /// </summary>
-        public virtual object Scalar(string sql, params object[] args)
-        {
+        public virtual object Scalar(string sql, params object[] args) {
             object result = null;
-            using (var conn = OpenConnection())
-            {
+            using (var conn = OpenConnection()) {
                 result = CreateCommand(sql, conn, args).ExecuteScalar();
             }
             return result;
@@ -270,8 +225,7 @@ namespace Massive
         /// <summary>
         /// Creates a DBCommand that you can use for loving your database.
         /// </summary>
-        DbCommand CreateCommand(string sql, DbConnection conn, params object[] args)
-        {
+        DbCommand CreateCommand(string sql, DbConnection conn, params object[] args) {
             var result = _factory.CreateCommand();
             result.Connection = conn;
             result.CommandText = sql;
@@ -282,8 +236,7 @@ namespace Massive
         /// <summary>
         /// Returns and OpenConnection
         /// </summary>
-        public virtual DbConnection OpenConnection()
-        {
+        public virtual DbConnection OpenConnection() {
             var result = _factory.CreateConnection();
             result.ConnectionString = ConnectionString;
             result.Open();
@@ -294,18 +247,15 @@ namespace Massive
         /// These objects can be POCOs, Anonymous, NameValueCollections, or Expandos. Objects
         /// With a PK property (whatever PrimaryKeyField is set to) will be created at UPDATEs
         /// </summary>
-        public virtual List<DbCommand> BuildCommands(params object[] things)
-        {
+        public virtual List<DbCommand> BuildCommands(params object[] things) {
             var commands = new List<DbCommand>();
             var items = (things.Length != 1) ? things : things[0] as System.Collections.IEnumerable;
-            foreach (var item in items)
-            {
-                if (HasPrimaryKey(item))
-                {
+            if (items == null) items = things;
+            foreach (var item in items) {
+                if (HasPrimaryKey(item)) {
                     commands.Add(CreateUpdateCommand(item, GetPrimaryKey(item)));
                 }
-                else
-                {
+                else {
                     commands.Add(CreateInsertCommand(item));
                 }
             }
@@ -316,33 +266,26 @@ namespace Massive
         /// These objects can be POCOs, Anonymous, NameValueCollections, or Expandos. Objects
         /// With a PK property (whatever PrimaryKeyField is set to) will be created at UPDATEs
         /// </summary>
-        public virtual int Save(params object[] things)
-        {
+        public virtual int Save(params object[] things) {
             var commands = BuildCommands(things);
             return Execute(commands);
         }
 
-        public virtual int Execute(DbCommand command)
-        {
+        public virtual int Execute(DbCommand command) {
             return Execute(new DbCommand[] { command });
         }
 
-        public virtual int Execute(string sql, params object[] args)
-        {
+        public virtual int Execute(string sql, params object[] args) {
             return Execute(CreateCommand(sql, null, args));
         }
         /// <summary>
         /// Executes a series of DBCommands in a transaction
         /// </summary>
-        public virtual int Execute(IEnumerable<DbCommand> commands)
-        {
+        public virtual int Execute(IEnumerable<DbCommand> commands) {
             var result = 0;
-            using (var conn = OpenConnection())
-            {
-                using (var tx = conn.BeginTransaction())
-                {
-                    foreach (var cmd in commands)
-                    {
+            using (var conn = OpenConnection()) {
+                using (var tx = conn.BeginTransaction()) {
+                    foreach (var cmd in commands) {
                         cmd.Connection = conn;
                         cmd.Transaction = tx;
                         result += cmd.ExecuteNonQuery();
@@ -357,16 +300,24 @@ namespace Massive
         /// Conventionally introspects the object passed in for a field that 
         /// looks like a PK. If you've named your PrimaryKeyField, this becomes easy
         /// </summary>
-        public virtual bool HasPrimaryKey(object o)
-        {
-            return o.ToDictionary().ContainsKey(PrimaryKeyField);
+        public virtual bool HasPrimaryKey(object o) {
+            bool result = o.ToDictionary().ContainsKey(PrimaryKeyField);
+            if (result) {
+                object pk = o.ToDictionary()[PrimaryKeyField];
+
+                Type pkType = pk.GetType();
+                if (pkType.IsPrimitive) {
+                    object pkDef = Activator.CreateInstance(pkType);
+                    return !pk.Equals(pkDef);
+                }
+            }
+            return result;
         }
         /// <summary>
         /// If the object passed in has a property with the same name as your PrimaryKeyField
         /// it is returned here.
         /// </summary>
-        public virtual object GetPrimaryKey(object o)
-        {
+        public virtual object GetPrimaryKey(object o) {
             object result = null;
             o.ToDictionary().TryGetValue(PrimaryKeyField, out result);
             return result;
@@ -375,8 +326,7 @@ namespace Massive
         /// <summary>
         /// Creates a command for use with transactions - internal stuff mostly, but here for you to play with
         /// </summary>
-        public virtual DbCommand CreateInsertCommand(object o)
-        {
+        public virtual DbCommand CreateInsertCommand(object o) {
             DbCommand result = null;
             var expando = o.ToExpando();
             var settings = (IDictionary<string, object>)expando;
@@ -385,15 +335,15 @@ namespace Massive
             var stub = "INSERT INTO {0} ({1}) \r\n VALUES ({2})";
             result = CreateCommand(stub, null);
             int counter = 0;
-            foreach (var item in settings)
-            {
-                sbKeys.AppendFormat("{0},", item.Key);
-                sbVals.AppendFormat("@{0},", counter.ToString());
-                result.AddParam(item.Value);
-                counter++;
+            foreach (var item in settings) {
+                if (String.Compare(item.Key, PrimaryKeyField, true) != 0) {
+                    sbKeys.AppendFormat("{0},", item.Key);
+                    sbVals.AppendFormat("@{0},", counter.ToString());
+                    result.AddParam(item.Value);
+                    counter++;
+                }
             }
-            if (counter > 0)
-            {
+            if (counter > 0) {
                 var keys = sbKeys.ToString().Substring(0, sbKeys.Length - 1);
                 var vals = sbVals.ToString().Substring(0, sbVals.Length - 1);
                 var sql = string.Format(stub, TableName, keys, vals);
@@ -405,8 +355,7 @@ namespace Massive
         /// <summary>
         /// Creates a command for use with transactions - internal stuff mostly, but here for you to play with
         /// </summary>
-        public virtual DbCommand CreateUpdateCommand(object o, object key)
-        {
+        public virtual DbCommand CreateUpdateCommand(object o, object key) {
             var expando = o.ToExpando();
             var settings = (IDictionary<string, object>)expando;
             var sbKeys = new StringBuilder();
@@ -414,18 +363,15 @@ namespace Massive
             var args = new List<object>();
             var result = CreateCommand(stub, null);
             int counter = 0;
-            foreach (var item in settings)
-            {
+            foreach (var item in settings) {
                 var val = item.Value;
-                if (!item.Key.Equals(PrimaryKeyField, StringComparison.OrdinalIgnoreCase) && item.Value != null)
-                {
+                if (!item.Key.Equals(PrimaryKeyField, StringComparison.OrdinalIgnoreCase) && item.Value != null) {
                     result.AddParam(val);
                     sbKeys.AppendFormat("{0} = @{1}, \r\n", item.Key, counter.ToString());
                     counter++;
                 }
             }
-            if (counter > 0)
-            {
+            if (counter > 0) {
                 //add the key
                 result.AddParam(key);
                 //strip the last commas
@@ -438,16 +384,13 @@ namespace Massive
         /// <summary>
         /// Removes one or more records from the DB according to the passed-in WHERE
         /// </summary>
-        public virtual DbCommand CreateDeleteCommand(string where = "", object key = null, params object[] args)
-        {
+        public virtual DbCommand CreateDeleteCommand(string where = "", object key = null, params object[] args) {
             var sql = string.Format("DELETE FROM {0} ", TableName);
-            if (key != null)
-            {
+            if (key != null) {
                 sql += string.Format("WHERE {0}=@0", PrimaryKeyField);
                 args = new object[] { key };
             }
-            else if (!string.IsNullOrEmpty(where))
-            {
+            else if (!string.IsNullOrEmpty(where)) {
                 sql += where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase) ? where : "WHERE " + where;
             }
             return CreateCommand(sql, null, args);
@@ -456,11 +399,9 @@ namespace Massive
         /// Adds a record to the database. You can pass in an Anonymous object, an ExpandoObject,
         /// A regular old POCO, or a NameValueColletion from a Request.Form or Request.QueryString
         /// </summary>
-        public virtual object Insert(object o)
-        {
+        public virtual object Insert(object o) {
             dynamic result = 0;
-            using (var conn = OpenConnection())
-            {
+            using (var conn = OpenConnection()) {
                 var cmd = CreateInsertCommand(o);
                 cmd.Connection = conn;
                 cmd.ExecuteNonQuery();
@@ -473,28 +414,24 @@ namespace Massive
         /// Updates a record in the database. You can pass in an Anonymous object, an ExpandoObject,
         /// A regular old POCO, or a NameValueCollection from a Request.Form or Request.QueryString
         /// </summary>
-        public virtual int Update(object o, object key)
-        {
+        public virtual int Update(object o, object key) {
             return Execute(CreateUpdateCommand(o, key));
         }
         /// <summary>
         /// Removes one or more records from the DB according to the passed-in WHERE
         /// </summary>
-        public int Delete(object key = null, string where = "", params object[] args)
-        {
+        public int Delete(object key = null, string where = "", params object[] args) {
             return Execute(CreateDeleteCommand(where: where, key: key, args: args));
         }
         /// <summary>
         /// Returns all records complying with the passed-in WHERE clause and arguments, 
         /// ordered as specified, limited (TOP) by limit.
         /// </summary>
-        public virtual IEnumerable<dynamic> All(string where = "", string orderBy = "", int limit = 0, string columns = "*", params object[] args)
-        {
+        public virtual IEnumerable<dynamic> All(string where = "", string orderBy = "", int limit = 0, string columns = "*", params object[] args) {
             string sql = BuildSelect(where, orderBy, limit);
             return Query(string.Format(sql, columns, TableName), args).ToList();
         }
-        private static string BuildSelect(string where, string orderBy, int limit)
-        {
+        private static string BuildSelect(string where, string orderBy, int limit) {
             string sql = limit > 0 ? "SELECT TOP " + limit + " {0} FROM {1} " : "SELECT {0} FROM {1} ";
             if (!string.IsNullOrEmpty(where))
                 sql += where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase) ? where : "WHERE " + where;
@@ -506,25 +443,21 @@ namespace Massive
         /// Returns all records complying with the passed-in WHERE clause and arguments, 
         /// ordered as specified, limited (TOP) by limit.
         /// </summary>
-        public virtual void AllAsync(Action<List<dynamic>> callback, string where = "", string orderBy = "", int limit = 0, string columns = "*", params object[] args)
-        {
+        public virtual void AllAsync(Action<List<dynamic>> callback, string where = "", string orderBy = "", int limit = 0, string columns = "*", params object[] args) {
             string sql = BuildSelect(where, orderBy, limit);
             QueryAsync(string.Format(sql, columns, TableName), callback, args);
         }
         /// <summary>
         /// Returns a dynamic PagedResult. Result properties are Items, TotalPages, and TotalRecords.
         /// </summary>
-        public virtual dynamic Paged(string where = "", string orderBy = "", string columns = "*", int pageSize = 20, int currentPage = 1, params object[] args)
-        {
+        public virtual dynamic Paged(string where = "", string orderBy = "", string columns = "*", int pageSize = 20, int currentPage = 1, params object[] args) {
             dynamic result = new ExpandoObject();
             var countSQL = string.Format("SELECT COUNT({0}) FROM {1}", PrimaryKeyField, TableName);
             if (String.IsNullOrEmpty(orderBy))
                 orderBy = PrimaryKeyField;
 
-            if (!string.IsNullOrEmpty(where))
-            {
-                if (!where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase))
-                {
+            if (!string.IsNullOrEmpty(where)) {
+                if (!where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase)) {
                     where = "WHERE " + where;
                 }
             }
@@ -542,31 +475,27 @@ namespace Massive
         /// <summary>
         /// Returns a single row from the database
         /// </summary>
-        public virtual dynamic Single(string where, params object[] args)
-        {
+        public virtual dynamic Single(string where, params object[] args) {
             var sql = string.Format("SELECT * FROM {0} WHERE {1}", TableName, where);
             return Query(sql, args).FirstOrDefault();
         }
         /// <summary>
         /// Returns a single row from the database
         /// </summary>
-        public virtual dynamic Single(object key, string columns = "*")
-        {
+        public virtual dynamic Single(object key, string columns = "*") {
             var sql = string.Format("SELECT {0} FROM {1} WHERE {2} = @0", columns, TableName, PrimaryKeyField);
             return Query(sql, key).FirstOrDefault();
         }
         /// <summary>
         /// A helpful query tool
         /// </summary>
-        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
-        {
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result) {
             //parse the method
             var constraints = new List<string>();
             var counter = 0;
             var info = binder.CallInfo;
             // accepting named args only... SKEET!
-            if (info.ArgumentNames.Count != args.Length)
-            {
+            if (info.ArgumentNames.Count != args.Length) {
                 throw new InvalidOperationException("Please use named arguments for this type of query - the column name, orderby, columns, etc");
             }
 
@@ -579,14 +508,11 @@ namespace Massive
             var whereArgs = new List<object>();
 
             //loop the named args - see if we have order, columns and constraints
-            if (info.ArgumentNames.Count > 0)
-            {
+            if (info.ArgumentNames.Count > 0) {
 
-                for (int i = 0; i < args.Length; i++)
-                {
+                for (int i = 0; i < args.Length; i++) {
                     var name = info.ArgumentNames[i].ToLower();
-                    switch (name)
-                    {
+                    switch (name) {
                         case "orderby":
                             orderBy = " ORDER BY " + args[i];
                             break;
@@ -602,8 +528,7 @@ namespace Massive
                 }
             }
             //Build the WHERE bits
-            if (constraints.Count > 0)
-            {
+            if (constraints.Count > 0) {
                 where = " WHERE " + string.Join(" AND ", constraints.ToArray());
             }
             //build the SQL
@@ -611,27 +536,22 @@ namespace Massive
             var justOne = op.StartsWith("First") || op.StartsWith("Last") || op.StartsWith("Get") || op.StartsWith("Single") || op.Equals("Find", StringComparison.InvariantCultureIgnoreCase) || op.Equals("FindBy", StringComparison.InvariantCultureIgnoreCase);
 
             //Be sure to sort by DESC on the PK (PK Sort is the default)
-            if (op.StartsWith("Last"))
-            {
+            if (op.StartsWith("Last")) {
                 orderBy = orderBy + " DESC ";
             }
-            else
-            {
+            else {
                 //default to multiple
                 sql = "SELECT " + columns + " FROM " + TableName + where;
             }
 
-            if (justOne)
-            {
+            if (justOne) {
                 //return a single record
                 result = Query(sql + orderBy, whereArgs.ToArray()).FirstOrDefault();
             }
-            else
-            {
+            else {
                 //return lots
                 result = Query(sql + orderBy, whereArgs.ToArray());
             }
-
             return true;
         }
     }


### PR DESCRIPTION
-got .Save working...passing collection into params objects[] was putting entire list into object[1] element preventing batch operations from working properly.
-have .All doing a .ToList<> at the end of it because enumerating the 'raw' IEnumerable that Query is returning seems to 'forget' it has been enumerated.
-treating Enums as string for the database(rather than integers). this follows in line with Linq2Sql behavior
