### PR TITLE
When "treat all warnings as errors" is set you get an error on line 175.

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -172,7 +172,7 @@ namespace Massive {
                 return result;
             }
         }
-        private string _descriptorField;
+        private string _descriptorField = null;
         public string DescriptorField {
             get {
                 return _descriptorField;


### PR DESCRIPTION
This just sets it to null as a default value.
