### PR TITLE
Fixes #99 - Resolved KeyValues method

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -118,7 +118,7 @@ namespace Massive {
             string primaryKeyField = "", string descriptorField = "", string sequence = "") {
             TableName = tableName == "" ? this.GetType().Name : tableName;
             PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
-
+            DescriptorField = descriptorField;
             _sequence = sequence == "" ? ConfigurationManager.AppSettings["default_seq"] : sequence;
             _factory = DbProviderFactories.GetFactory("System.Data.OracleClient");
             if (ConfigurationManager.ConnectionStrings[connectionStringName] == null)
@@ -177,12 +177,7 @@ namespace Massive {
                 return result;
             }
         }
-        private string _descriptorField;
-        public string DescriptorField {
-            get {
-                return _descriptorField;
-            }
-        }
+        public string DescriptorField { get; protected set; }
         /// <summary>
         /// List out all the schema bits for use with ... whatever
         /// </summary>
@@ -369,7 +364,9 @@ namespace Massive {
             var sql = string.Format("SELECT {0},{1} FROM {2} ", PrimaryKeyField, DescriptorField, TableName);
             if (!String.IsNullOrEmpty(orderBy))
                 sql += "ORDER BY " + orderBy;
-            return (IDictionary<string, object>)Query(sql);
+
+            var results = Query(sql).ToList().Cast<IDictionary<string, object>>()
+            return results.ToDictionary(key => key[PrimaryKeyField].ToString(), value => value[DescriptorField]);
         }
 
         /// <summary>

--- a/Massive.cs
+++ b/Massive.cs
@@ -117,6 +117,7 @@ namespace Massive {
             string primaryKeyField = "", string descriptorField = "") {
             TableName = tableName == "" ? this.GetType().Name : tableName;
             PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
+            DescriptorField = descriptorField;
             var _providerName = "System.Data.SqlClient";
             _factory = DbProviderFactories.GetFactory(_providerName);
             ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
@@ -172,12 +173,7 @@ namespace Massive {
                 return result;
             }
         }
-        private string _descriptorField = null;
-        public string DescriptorField {
-            get {
-                return _descriptorField;
-            }
-        }
+        public string DescriptorField { get; protected set; }
         /// <summary>
         /// List out all the schema bits for use with ... whatever
         /// </summary>
@@ -363,7 +359,9 @@ namespace Massive {
             var sql = string.Format("SELECT {0},{1} FROM {2} ", PrimaryKeyField, DescriptorField, TableName);
             if (!String.IsNullOrEmpty(orderBy))
                 sql += "ORDER BY " + orderBy;
-            return (IDictionary<string, object>)Query(sql);
+
+            var results = Query(sql).ToList().Cast<IDictionary<string, object>>();
+            return results.ToDictionary(key => key[PrimaryKeyField].ToString(), value => value[DescriptorField]);
         }
 
         /// <summary>


### PR DESCRIPTION
The KeyValues method was returning an IEnumerable<dynamic> rather than an IDictionary<string, object>.  This was because the Query() method returned a list of results, but we only needed to return the key/value pairs of those individual results as the dictionary.

Let me know if you'd like this implemented differently, or just removed.  I've noticed that the KeyValues() method is only in Massive.cs and Massive.Oracle.cs.  Not sure if you would like it in the other two also.

Thanks!
