### PR TITLE
Fixed an issue with POCO's and Identity Insert Conflicts.

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -75,8 +75,9 @@ namespace Massive {
             } else {
                 var props = o.GetType().GetProperties();
                 foreach (var item in props) {
-                    if(!exclusions.Contains(item.Name))
+                    if(!exclusions.Contains(item.Name)) {
                         d.Add(item.Name, item.GetValue(o, null));
+                    }
                 }
             }
             return result;


### PR DESCRIPTION
Hey Rob,
Big fan of Massive, used it in 2 projects already.  Found a little issue though (at least with my usage).

When you try and Insert() a POCO it will most likely fail because of an Identity Insert Specification Conflict on the table's Primary Key column.

To remedy this I added an exclusion params to ToExpando() so that the Insert method can automatically exclude the Primary Key.  After making that small tweak, the issue cleared up because we're no longer trying to set the Primary Key in the insert.

I know that this could be unwanted default behavior, but I feel that this is more the norm.  Wanting to set the Primary Key on an insert is probably an edge case.  Let me know if I'm doing it wrong.

Thanks,
John Bubriski
