### PR TITLE
Added ToExpando() calls before creating the commands in BuildCommands()....

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -247,9 +247,9 @@ namespace Massive {
             var commands = new List<DbCommand>();
             foreach (var item in things) {
                 if (HasPrimaryKey(item)) {
-                    commands.Add(CreateUpdateCommand(item, GetPrimaryKey(item)));
+                    commands.Add(CreateUpdateCommand(item.ToExpando(), GetPrimaryKey(item)));
                 } else {
-                    commands.Add(CreateInsertCommand(item));
+                    commands.Add(CreateInsertCommand(item.ToExpando()));
                 }
             }
             return commands;


### PR DESCRIPTION
...  This was causing an issue where a call to Save() with a POCO would blow up.  The POCO wouldn't get turned into an ExpandoObject, and would blow up when passed to CreateUpdateCommand() or CreateInsertCommand() (from Save()).
