### PR TITLE
Paged method error

### DIFF
--- a/fixes_readme.txt
+++ b/fixes_readme.txt
@@ -1,0 +1,3 @@
+Harsh Bhasin 11/18/2011
+
+added a space before the WHERE clause in the Paged method at line 337 in Massive.cs


### PR DESCRIPTION
added a space before the WHERE clause in the Paged method at line 337 in Massive.cs. 

Without this space the  sql reads like this and fails: select \* from tablenameWhere something ="abc"
