### PR TITLE
Massive with Sql CE 4.0 - Provider Tweak

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -119,6 +119,10 @@ namespace Massive {
             PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
             DescriptorField = descriptorField;
             var _providerName = "System.Data.SqlClient";
+            
+            if(ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName != null)
+                _providerName = ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName;
+            
             _factory = DbProviderFactories.GetFactory(_providerName);
             ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
         }


### PR DESCRIPTION
Tweaked the database provider code to use the provider as defined in connection string if one is available. This solved an issue when trying to use a Sql Compact Database 4.0 provider with Massive.
