### PR TITLE
Massive.Oracle.cs

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -185,7 +185,7 @@ namespace Massive {
         public IEnumerable<dynamic> Schema {
             get {
                 if (_schema == null)
-                    _schema = Query("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @0", TableName);
+                    _schema = Query("SELECT * FROM USER_TAB_COLUMNS WHERE TABLE_NAME = :0", TableName);
                 return _schema;
             }
         }


### PR DESCRIPTION
Rob, 
I modified this file to use USER_TAB_COLUMNS instead of the INFORMATION_SCHEMA.COLUMNS in the query for a Table schema and corrected the parameter syntax.

Larry Northcutt
