### PR TITLE
put [] around the table name in the CreateInsertCommand

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -424,7 +424,7 @@ namespace Massive {
             var settings = (IDictionary<string, object>)expando;
             var sbKeys = new StringBuilder();
             var sbVals = new StringBuilder();
-            var stub = "INSERT INTO {0} ({1}) \r\n VALUES ({2})";
+            var stub = "INSERT INTO [{0}] ({1}) \r\n VALUES ({2})";
             result = CreateCommand(stub, null);
             int counter = 0;
             foreach (var item in settings) {


### PR DESCRIPTION
we had a table called Order which is a keyword in sql.
using [] around the table name will allow for a statement like this.
INSERT INTO [Order](Product) VALUES ('Hat')
