### PR TITLE
Allow for the usage of a provider supplied in the connection string.

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -257,9 +257,9 @@ namespace Massive.Oracle {
             var commands = new List<DbCommand>();
             foreach (var item in things) {
                 if (HasPrimaryKey(item)) {
-                    commands.Add(CreateUpdateCommand(item, GetPrimaryKey(item)));
+                    commands.Add(CreateUpdateCommand(item.ToExpando(), GetPrimaryKey(item)));
                 } else {
-                    commands.Add(CreateInsertCommand(item));
+                    commands.Add(CreateInsertCommand(item.ToExpando()));
                 }
             }
             return commands;


### PR DESCRIPTION
Massive.Oracle.cs was hard coded to use System.Data.OracleClient as the DbProviderFactory. This change will keep that as a default unless a provider name is specified in the connection string entry.
