### PR TITLE
Check on primary key field when inserting object 

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -427,7 +427,7 @@ namespace Massive {
             var stub = "INSERT INTO {0} ({1}) \r\n VALUES ({2})";
             result = CreateCommand(stub, null);
             int counter = 0;
-            foreach (var item in settings) {
+            foreach (var item in settings.Where(s => s.Key != PrimaryKeyField))
                 sbKeys.AppendFormat("{0},", item.Key);
                 sbVals.AppendFormat("@{0},", counter.ToString());
                 result.AddParam(item.Value);


### PR DESCRIPTION
Since we assume an identity column anyway (we check for @@IDENTITY after insert) let's assume that the identity column is the same as the primary key. 
If I insert a POCO the primary key column is there and thus the column is added to the SQL insert statement. SQL won't allow that gving a "set identity_insert is off for table 'xxx'.  Proposed change filters the primary key column out from the list of properties.
