### PR TITLE
Added support for full connection string passed to constructor or con

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -68,13 +68,12 @@ namespace Massive {
         public static dynamic ToExpando(this object o) {
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
-            Type oType = o.GetType();
-            if (oType == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
-            if (oType == typeof(NameValueCollection) || oType.IsSubclassOf(typeof(NameValueCollection))) {
+            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
+            if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection))) {
                 var nv = (NameValueCollection)o;
-                nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(d.Add);
+                nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(i => d.Add(i));
             } else {
-                var props = oType.GetProperties();
+                var props = o.GetType().GetProperties();
                 foreach (var item in props) {
                     d.Add(item.Name, item.GetValue(o, null));
                 }


### PR DESCRIPTION
Allows a full connection string to be passed to the constructor while
still supporting the connection string name from config file. This
allows for environments or situations where you don't use the a config
file. Also renamed ConnectionString to _connectionString to be inlined
with visible naming conventions in the file, which is also in line with
common conventions for C#.
