### PR TITLE
Null Ref and Missing using statement

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -204,10 +204,10 @@ namespace Massive.Oracle {
         /// Enumerates the reader yielding the result - thanks to Jeroen Haegebaert
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
-            using (var conn = OpenConnection()) {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+            using (var conn = OpenConnection()) 
+            using (var rdr = CreateCommand(sql, conn, args).ExecuteReader()) {
                 while (rdr.Read()) {
-                    yield return rdr.RecordToExpando(); ;
+                    yield return rdr.RecordToExpando();
                 }
             }
         }

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -234,14 +234,11 @@ namespace Massive.PostgreSQL
         /// <summary>
         /// Enumerates the reader yielding the result - thanks to Jeroen Haegebaert
         /// </summary>
-        public virtual IEnumerable<dynamic> Query(string sql, params object[] args)
-        {
-            using (var conn = OpenConnection())
-            {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read())
-                {
-                    yield return rdr.RecordToExpando(); ;
+        public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
+            using (var conn = OpenConnection()) 
+            using (var rdr = CreateCommand(sql, conn, args).ExecuteReader()) {
+                while (rdr.Read()) {
+                    yield return rdr.RecordToExpando();
                 }
             }
         }

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -230,19 +230,14 @@ namespace Massive.SQLite
         /// <summary>
         /// Enumerates the reader yielding the result - thanks to Jeroen Haegebaert
         /// </summary>
-        public virtual IEnumerable<dynamic> Query(string sql, params object[] args)
-        {
-            using (var conn = OpenConnection())
-            {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read())
-                {
-                    yield return rdr.RecordToExpando(); ;
+        public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
+           using (var conn = OpenConnection()) 
+            using (var rdr = CreateCommand(sql, conn, args).ExecuteReader()) {
+                while (rdr.Read()) {
+                    yield return rdr.RecordToExpando();
                 }
             }
         }
-      
-
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args)
         {
             using (var rdr = CreateCommand(sql, connection, args).ExecuteReader())

--- a/Massive.cs
+++ b/Massive.cs
@@ -194,10 +194,10 @@ namespace Massive {
         /// Enumerates the reader yielding the result - thanks to Jeroen Haegebaert
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
-            using (var conn = OpenConnection()) {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+            using (var conn = OpenConnection()) 
+            using (var rdr = CreateCommand(sql, conn, args).ExecuteReader()) {
                 while (rdr.Read()) {
-                    yield return rdr.RecordToExpando(); ;
+                    yield return rdr.RecordToExpando();
                 }
             }
         }


### PR DESCRIPTION
Null exception if value is null
Changed double if statements in ValidatesPresenceOf into an if/else statement, because if the value is null it would through a NullReferenceException when it called ToString on it.

In ValidateIsCurrency added a return after value == null check is true as we don't need to process the rest of the method and if you did and value was null he ToString call would throw a NullReferenceException.

Missing using statement
Using statement is missing, this should be disposing the reader when done. It is in sycn with the other Query method now as well.
