### PR TITLE
Removed SQLite DLL dependency

### DIFF
--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -8,7 +8,6 @@ using System.Dynamic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Data.SQLite;
 
 namespace Massive.SQLite
 {


### PR DESCRIPTION
Removed the unneeded using statement for System.Data.SQLite which
required a dependency on the 3rd party SQLite DLL.  This using wasn't
required to compile so no need to require the dependeny on a 3rd party
DLL.  Now the only dependency for all Massive files is .NET 4.0 or
higher.
