### PR TITLE
removed brackets from INSERT INTO

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -424,7 +424,7 @@ namespace Massive {
             var settings = (IDictionary<string, object>)expando;
             var sbKeys = new StringBuilder();
             var sbVals = new StringBuilder();
-            var stub = "INSERT INTO [{0}] ({1}) \r\n VALUES ({2})";
+            var stub = "INSERT INTO {0} ({1}) \r\n VALUES ({2})";
             result = CreateCommand(stub, null);
             int counter = 0;
             foreach (var item in settings) {


### PR DESCRIPTION
Brackets were added to the INSERT INTO statement around the table name. This causes an error when using schemas. The INSERT INTO statements have a table name of [schema.table] instead of [schema].[table].

I removed this change. A correct implementation would include proper schema handling as well as applying the change for all statements, not just INSERT INTO.
