### PR TITLE
Adds Ability Pass Full Connection String to Cstor

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -104,6 +104,7 @@ namespace Massive.Oracle {
     /// A class that wraps your database table in Dynamic Funtime
     /// </summary>
     public class DynamicModel : DynamicObject {
+        private const string DefaultProviderName = "System.Data.OracleClient";
         DbProviderFactory _factory;
         string ConnectionString;
         string _sequence;
@@ -112,29 +113,17 @@ namespace Massive.Oracle {
             dynamic dm = new DynamicModel(connectionStringName);
             return dm;
         }
-
-        public DynamicModel(string connectionStringName, string tableName = "",
-            string primaryKeyField = "", string descriptorField = "", string sequence = "") {
-
-            TableName = tableName == "" ? this.GetType().Name : tableName;
-            PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
-            DescriptorField = descriptorField;
-            _sequence = sequence == "" ? ConfigurationManager.AppSettings["default_seq"] : sequence;
-
-            var _providerName = "System.Data.OracleClient";
-            var _connectionStringKey = ConfigurationManager.ConnectionStrings[connectionStringName];
-
-            if (_connectionStringKey == null) {
-                ConnectionString = connectionStringName;
-            } else {
-                ConnectionString = _connectionStringKey.ConnectionString;
-                if (!string.IsNullOrEmpty(_connectionStringKey.ProviderName)) {
-                    _providerName = _connectionStringKey.ProviderName;
-                }
-            }
-
-            _factory = DbProviderFactories.GetFactory(_providerName);
-
+        public DynamicModel(string connectionStringOrName, string tableName = null,
+            string primaryKeyField = null, string descriptorField = null, string sequence = null) {
+            TableName = string.IsNullOrWhiteSpace(tableName) ? GetType().Name : tableName;
+            PrimaryKeyField = string.IsNullOrWhiteSpace(primaryKeyField) ? "ID" : primaryKeyField;
+            DescriptorField = descriptorField ?? string.Empty;
+            _sequence = string.IsNullOrWhiteSpace(sequence) ? ConfigurationManager.AppSettings["default_seq"] : sequence;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[connectionStringOrName];
+            // if settings is null assume they provided full connecton string
+            ConnectionString = settings == null ? connectionStringOrName : settings.ConnectionString;
+            _factory = DbProviderFactories.GetFactory(settings == null ? DefaultProviderName : settings.ProviderName);
+            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringOrName].ConnectionString;
         }
 
         /// <summary>

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -134,6 +134,7 @@ namespace Massive.PostgreSQL
     /// </summary>
     public class DynamicModel : DynamicObject
     {
+        private const string DefaultProviderName = "Npgsql";
         DbProviderFactory _factory;
         string ConnectionString;
         public static DynamicModel Open(string connectionStringName)
@@ -144,12 +145,15 @@ namespace Massive.PostgreSQL
         public DynamicModel(string connectionStringName, string tableName = "",
             string primaryKeyField = "", string descriptorField = "")
         {
-            TableName = tableName == "" ? this.GetType().Name : tableName;
-            PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
-            DescriptorField = descriptorField;
-            var _providerName = "Npgsql";
-            _factory = DbProviderFactories.GetFactory(_providerName);
-            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
+            string primaryKeyField = null, string descriptorField = null) {
+            TableName = string.IsNullOrWhiteSpace(tableName) ? GetType().Name : tableName;
+            PrimaryKeyField = string.IsNullOrWhiteSpace(primaryKeyField) ? "ID" : primaryKeyField;
+            DescriptorField = descriptorField ?? string.Empty;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[connectionStringOrName];
+            // if settings is null assume they provided full connecton string
+            ConnectionString = settings == null ? connectionStringOrName : settings.ConnectionString;
+            _factory = DbProviderFactories.GetFactory(settings == null ? DefaultProviderName : settings.ProviderName);
+            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringOrName].ConnectionString;
         }
 
         /// <summary>

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -113,6 +113,7 @@ namespace Massive.SQLite
     /// </summary>
     public class DynamicModel : DynamicObject
     {
+        private const string DefaultProviderName = "System.Data.SQLite";
         DbProviderFactory _factory;
         string ConnectionString;
         public static DynamicModel Open(string connectionStringName)
@@ -122,12 +123,13 @@ namespace Massive.SQLite
         }
         public DynamicModel(string connectionStringName, string tableName = "", string primaryKeyField = "")
         {
-            TableName = tableName == "" ? this.GetType().Name : tableName;
-            PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
-            var _providerName = "System.Data.SQLite";
-            _factory = DbProviderFactories.GetFactory(_providerName);
-            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
-            _providerName = ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName;
+            TableName = string.IsNullOrWhiteSpace(tableName) ? GetType().Name : tableName;
+            PrimaryKeyField = string.IsNullOrWhiteSpace(primaryKeyField) ? "ID" : primaryKeyField;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[connectionStringOrName];
+            // if settings is null assume they provided full connecton string
+            ConnectionString = settings == null ? connectionStringOrName : settings.ConnectionString;
+            _factory = DbProviderFactories.GetFactory(settings == null ? DefaultProviderName : settings.ProviderName);
+            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringOrName].ConnectionString;
         }
 
         /// <summary>

--- a/Massive.cs
+++ b/Massive.cs
@@ -107,24 +107,23 @@ namespace Massive {
     /// A class that wraps your database table in Dynamic Funtime
     /// </summary>
     public class DynamicModel : DynamicObject {
+        private const string DefaultProviderName = "System.Data.SqlClient";
         DbProviderFactory _factory;
         string ConnectionString;
         public static DynamicModel Open(string connectionStringName) {
             dynamic dm = new DynamicModel(connectionStringName);
             return dm;
         }
-        public DynamicModel(string connectionStringName, string tableName = "",
-            string primaryKeyField = "", string descriptorField = "") {
-            TableName = tableName == "" ? this.GetType().Name : tableName;
-            PrimaryKeyField = string.IsNullOrEmpty(primaryKeyField) ? "ID" : primaryKeyField;
-            DescriptorField = descriptorField;
-            var _providerName = "System.Data.SqlClient";
-            
-            if(ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName != null)
-                _providerName = ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName;
-            
-            _factory = DbProviderFactories.GetFactory(_providerName);
-            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString;
+        public DynamicModel(string connectionStringOrName, string tableName = null,
+            string primaryKeyField = null, string descriptorField = null) {
+            TableName = string.IsNullOrWhiteSpace(tableName) ? GetType().Name : tableName;
+            PrimaryKeyField = string.IsNullOrWhiteSpace(primaryKeyField) ? "ID" : primaryKeyField;
+            DescriptorField = descriptorField ?? string.Empty;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[connectionStringOrName];
+            // if settings is null assume they provided full connecton string
+            ConnectionString = settings == null ? connectionStringOrName : settings.ConnectionString;
+            _factory = DbProviderFactories.GetFactory(settings == null ? DefaultProviderName : settings.ProviderName);
+            ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringOrName].ConnectionString;
         }
 
         /// <summary>

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ How Do You Use It?
 ------------------
 Massive is a "wrapper" for your DB tables and uses System.Dynamic extensively. If you try to use this with C# 3.5 or below, it will explode and you will be sad. Me too honestly - I like how this doesn't require any DLLs other than what's in the GAC. Yippee.
 
- * Get a Database. Northwind will work nicely. Add a connection to your database in your web.config (or app.config). Don't forget the providerName! If you don't know what that is - just add providerName = 'System.Data.SqlClient' right after the whole connectionString stuff.
+ * Get a Database. Northwind will work nicely. Add a connection to your database in your web.config (or app.config). Don't forget the providerName! If you don't know what that is - just add providerName = 'System.Data.SqlClient' right after the whole connectionString stuff. If you don't use a config file you can pass the whole connection string to the constructor instead of the name.
  * Create a class that wraps a table. You can call it whatever you like, but if you want to be cool just name it the same as your table.
  * Query away and have fun
 
@@ -191,8 +191,13 @@ Factory Constructor
 -------------------
 One thing that can be useful is to use Massive to just run a quick query. You can do that now by using "Open()" which is a static builder on DynamicModel:
 
+Open by ConntectionString Name in config file:
 ```csharp
 var db = Massive.DynamicModel.Open("myConnectionStringName");
+```
+Open by ConnectionString:
+```csharp
+var db = Massive.DynamicModel.Open("Data Source=myserver.domain;Initial Catalog=mycatalog;Integrated Security=True;");
 ```
 
 You can execute whatever you like at that point.


### PR DESCRIPTION
Adds ability to pass the full connection string into constructor instead
of only the name in the config file. You can still pass by name. This is
useful when you don't have the connection string in the config file
and/or you are building them up programmatically.
