### PR TITLE
Null exception if value is null

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -549,7 +549,7 @@ namespace Massive.Oracle {
         public virtual void ValidatesPresenceOf(object value, string message = "Required") {
             if (value == null)
                 Errors.Add(message);
-            if (String.IsNullOrEmpty(value.ToString()))
+            else if (String.IsNullOrEmpty(value.ToString()))
                 Errors.Add(message);
         }
         //fun methods

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -664,7 +664,7 @@ namespace Massive.PostgreSQL
         {
             if (value == null)
                 Errors.Add(message);
-            if (String.IsNullOrEmpty(value.ToString()))
+            else if (String.IsNullOrEmpty(value.ToString()))
                 Errors.Add(message);
         }
         //fun methods

--- a/Massive.cs
+++ b/Massive.cs
@@ -561,7 +561,7 @@ namespace Massive {
         public virtual void ValidatesPresenceOf(object value, string message = "Required") {
             if (value == null)
                 Errors.Add(message);
-            if (String.IsNullOrEmpty(value.ToString()))
+            else if (String.IsNullOrEmpty(value.ToString()))
                 Errors.Add(message);
         }
         //fun methods
@@ -573,8 +573,10 @@ namespace Massive {
             }
         }
         public virtual void ValidateIsCurrency(object value, string message = "Should be money") {
-            if (value == null)
+            if (value == null) {
                 Errors.Add(message);
+                return;
+            }
             decimal val = decimal.MinValue;
             decimal.TryParse(value.ToString(), out val);
             if (val == decimal.MinValue)


### PR DESCRIPTION
Changed double if statements in ValidatesPresenceOf into an if/else
statement, because if the value is null it would through a
NullReferenceException when it called ToString on it.

In ValidateIsCurrency added a return after value == null check is true
as we don't need to process the rest of the method and if you did and
value was null he ToString call would throw a NullReferenceException.
