### PR TITLE
Added explicit dispose to Sqlite commands and data reader.

### DIFF
--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -250,6 +250,7 @@ namespace Massive.SQLite
                 {
                     yield return rdr.RecordToExpando(); ;
                 }
+                rdr.Dispose();
             }
         }
         /// <summary>
@@ -342,6 +343,7 @@ namespace Massive.SQLite
                         cmd.Connection = conn;
                         cmd.Transaction = tx;
                         result += cmd.ExecuteNonQuery();
+                        cmd.Dispose();
                     }
                     tx.Commit();
                 }
@@ -462,6 +464,7 @@ namespace Massive.SQLite
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = "select last_insert_rowid()";
                 result = cmd.ExecuteScalar();
+                cmd.Dispose();
             }
             return result;
         }


### PR DESCRIPTION
I was having issues when performing inserts while looping and discovered that after ~15 iterations/inserts it would lock the database file.   Upon adding the explicit dispose to the commands, the issue did not reoccur.  I also added a dispose to the reader object for good measure.

The issue and resolution are also described here in Sqlite's ticketing system.
http://system.data.sqlite.org/index.html/info/3186bfc523
