### PR TITLE
Removed primary key insertion

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -428,6 +428,9 @@ namespace Massive {
             result = CreateCommand(stub, null);
             int counter = 0;
             foreach (var item in settings) {
+                if (item.Key.Equals(PrimaryKeyField, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
                 sbKeys.AppendFormat("{0},", item.Key);
                 sbVals.AppendFormat("@{0},", counter.ToString());
                 result.AddParam(item.Value);


### PR DESCRIPTION
The primary key, if set, shouldn't be inserted, because it will be automatically generated (in most scenarios).

This could be a breaking change for the few people that don't automatically generate keys on the server. You could add another boolean property such as PrimaryKeyAutogenerated if you wanted. This pull request will help most people, most of the time though.
