### PR TITLE
Bug fix - Missing space meant paged where statements weren't working

### DIFF
--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -505,7 +505,7 @@ namespace Massive.SQLite
         public virtual dynamic Paged(string where = "", string orderBy = "", string columns = "*", int pageSize = 20, int currentPage = 1, params object[] args)
         {
             dynamic result = new ExpandoObject();
-            var countSQL = string.Format("SELECT COUNT({0}) FROM {1}", PrimaryKeyField, TableName);
+            var countSQL = string.Format("SELECT COUNT({0}) FROM {1} ", PrimaryKeyField, TableName);
             if (String.IsNullOrEmpty(orderBy))
                 orderBy = PrimaryKeyField;
 


### PR DESCRIPTION
Missing space meant paged where statements weren't working
