### PR TITLE
Fixing ProviderName check that fails because it returns an empty string

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -120,7 +120,7 @@ namespace Massive {
             DescriptorField = descriptorField;
             var _providerName = "System.Data.SqlClient";
             
-            if(ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName != null)
+            if (!string.IsNullOrWhiteSpace(ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName))
                 _providerName = ConfigurationManager.ConnectionStrings[connectionStringName].ProviderName;
             
             _factory = DbProviderFactories.GetFactory(_providerName);


### PR DESCRIPTION
Hey Rob,

I didn't have a providerName specified in my connection string and it found an empty string and didn't use the default providerName.

Thanks,
Tim
