### PR TITLE
CreateUpdateCommand fix for zero length string

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -454,7 +454,7 @@ namespace Massive {
             foreach (var item in settings) {
                 var val = item.Value;
                 if (!item.Key.Equals(PrimaryKeyField, StringComparison.OrdinalIgnoreCase) && item.Value != null) {
-                    if (String.IsNullOrEmpty(item.Value.ToString())) { val = "Null"; };
+                    if (String.IsNullOrEmpty(item.Value.ToString())) { val = null; };
                     result.AddParam(val);
                     sbKeys.AppendFormat("{0} = @{1}, \r\n", item.Key, counter.ToString());
                     counter++;


### PR DESCRIPTION
If you try to submit form that has some empty fields and then try to update the database using

table.Update(Request.Form, ID);

You might get error saying

The UPDATE statement conflicted with the CHECK constraint - Allow Zero Length.

This change fixes it by replacing empty string with 'Null'.
