### PR TITLE
Adds a `using` statement to a `Query` overload

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -316,7 +316,7 @@ namespace Massive.Oracle {
             string sql = BuildSelect(where, orderBy, limit);
             return Query(string.Format(sql, columns, TableName), args);
         }
-        private static string BuildSelect(string where, string orderBy, int limit) {
+        protected static string BuildSelect(string where, string orderBy, int limit) {
             string sql = "SELECT {0} FROM {1} ";
             if (!string.IsNullOrEmpty(where))
                 sql += where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase) ? where : "WHERE " + where;

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -371,7 +371,7 @@ namespace Massive.PostgreSQL
             string sql = BuildSelect(where, orderBy, limit);
             return Query(string.Format(sql, columns, TableName), args);
         }
-        private static string BuildSelect(string where, string orderBy, int limit)
+        protected static string BuildSelect(string where, string orderBy, int limit)
         {
             string sql = "SELECT {0} FROM {1} ";
             if (!string.IsNullOrEmpty(where))

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -491,7 +491,7 @@ namespace Massive.SQLite
             string sql = BuildSelect(where, orderBy, limit);
             return Query(string.Format(sql, columns, TableName), args);
         }
-        private static string BuildSelect(string where, string orderBy, int limit)
+        protected static string BuildSelect(string where, string orderBy, int limit)
         {
             string sql = limit > 0 ? "SELECT TOP " + limit + " {0} FROM {1} " : "SELECT {0} FROM {1} ";
             if (!string.IsNullOrEmpty(where))

--- a/Massive.cs
+++ b/Massive.cs
@@ -306,7 +306,7 @@ namespace Massive {
             string sql = BuildSelect(where, orderBy, limit);
             return Query(string.Format(sql, columns, TableName), args);
         }
-        private static string BuildSelect(string where, string orderBy, int limit) {
+        protected static string BuildSelect(string where, string orderBy, int limit) {
             string sql = limit > 0 ? "SELECT TOP " + limit + " {0} FROM {1} " : "SELECT {0} FROM {1} ";
             if (!string.IsNullOrEmpty(where))
                 sql += where.Trim().StartsWith("where", StringComparison.OrdinalIgnoreCase) ? where : " WHERE " + where;


### PR DESCRIPTION
Adds a `using` statement wrapping the `DbDataReader` access missing in
`public IEnumerable<dynamic> Query(string sql, params object[] args)`
method overload.

This caused `database locked` errors when you executed a query followed
immediately by an `INSERT` to the database in methods using this `Query`'s
overload.

For example, using `First` method this way:

```
var obj = table.First(...).id;
table.Insert(...);
```

will yield a `database locked` error because the `rdr` in `Query` is
not being closed/disposed.

The other `Query`'s overload had it so I assume this one must had been
forgotten.
