### PR TITLE
@@IDENTITY can be hijacked via triggers; replaced with SCOPE_IDENTITY().

### DIFF
--- a/Massive.cs
+++ b/Massive.cs
@@ -7,9 +7,6 @@ using System.Data.Common;
 using System.Dynamic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using System.Data.SqlClient;
-using System.Text.RegularExpressions;
 
 namespace Massive {
     public static class ObjectExtensions {
@@ -503,8 +500,8 @@ namespace Massive {
                 using (dynamic conn = OpenConnection()) {
                     var cmd = CreateInsertCommand(ex);
                     cmd.Connection = conn;
-                    cmd.ExecuteNonQuery();
-                    cmd.CommandText = "SELECT @@IDENTITY as newID";
+                    // Append selecting SCOPE_IDENTITY() to the query to get the new ID.
+                    cmd.CommandText = string.Format("{0}; SELECT SCOPE_IDENTITY() as newID", cmd.CommandText);
                     ex.ID = cmd.ExecuteScalar();
                     Inserted(ex);
                 }


### PR DESCRIPTION
Long story short, I was using massive on a development database where a co-worker has set up an audit table via triggers (don't ask). Inserting data resulted in the ID for the audit record coming back, instead of the ID of the item I was attempting to insert. 

Phil Haack gives a very clear description of the issue here: http://haacked.com/archive/2005/04/11/beware-of-@@identity-theft-in-sql-server.aspx

The solution is moderately simple: switch out @@IDENTITY for SCOPE_IDENTITY(). Unfortunately this means that I had to stay within the query scope, which resulted in some string concatenation with the INSERT query instead of running a second query, which I'm not 100% comfortable with (hence why I'm glad someone has to read this before accepting the pull request). It does work however.
