### PR TITLE
Use Query overload

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -205,10 +205,7 @@ namespace Massive.Oracle {
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
             using (var conn = OpenConnection()) {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read()) {
-                    yield return rdr.RecordToExpando(); ;
-                }
+                return Query(sql, conn, args);
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args) {

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -238,11 +238,7 @@ namespace Massive.PostgreSQL
         {
             using (var conn = OpenConnection())
             {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read())
-                {
-                    yield return rdr.RecordToExpando(); ;
-                }
+                return Query(sql,conn,args);
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args)

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -233,11 +233,7 @@ namespace Massive.SQLite
         {
             using (var conn = OpenConnection())
             {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read())
-                {
-                    yield return rdr.RecordToExpando(); ;
-                }
+                return Query(sql, conn, args);
             }
         }
       

--- a/Massive.cs
+++ b/Massive.cs
@@ -195,10 +195,7 @@ namespace Massive {
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
             using (var conn = OpenConnection()) {
-                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
-                while (rdr.Read()) {
-                    yield return rdr.RecordToExpando(); ;
-                }
+                return Query(sql, conn, args);
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args) {


### PR DESCRIPTION
I noticed that a similar change can be made in the other `.cs` files so I made sure to mention the file name in the commit message. 

Am I correct in thinking using `return` like this will preserve the laziness of `yield`? 