### PR TITLE
Check is expando first to avoid allocation

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -63,9 +63,9 @@ namespace Massive.Oracle {
         /// Turns the object into an ExpandoObject
         /// </summary>
         public static dynamic ToExpando(this object o) {
+            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
-            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection))) {
                 var nv = (NameValueCollection)o;
                 nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(i => d.Add(i));

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -83,9 +83,9 @@ namespace Massive.PostgreSQL
         /// </summary>
         public static dynamic ToExpando(this object o)
         {
+            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
-            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection)))
             {
                 var nv = (NameValueCollection)o;

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -81,9 +81,9 @@ namespace Massive.SQLite
         /// </summary>
         public static dynamic ToExpando(this object o)
         {
+            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
-            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection)))
             {
                 var nv = (NameValueCollection)o;

--- a/Massive.cs
+++ b/Massive.cs
@@ -66,9 +66,9 @@ namespace Massive {
         /// Turns the object into an ExpandoObject
         /// </summary>
         public static dynamic ToExpando(this object o) {
+            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             var result = new ExpandoObject();
             var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
-            if (o.GetType() == typeof(ExpandoObject)) return o; //shouldn't have to... but just in case
             if (o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection))) {
                 var nv = (NameValueCollection)o;
                 nv.Cast<string>().Select(key => new KeyValuePair<string, object>(key, nv[key])).ToList().ForEach(i => d.Add(i));


### PR DESCRIPTION
`toExpando` I noticed that the check if the incoming object is already expando could happen first to avoid the allocation. Nothing ground shaking but I don't think it hurts anything.