### PR TITLE
Revert "Use Query overload"

### DIFF
--- a/Massive.Oracle.cs
+++ b/Massive.Oracle.cs
@@ -205,7 +205,10 @@ namespace Massive.Oracle {
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
             using (var conn = OpenConnection()) {
-                return Query(sql, conn, args);
+                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+                while (rdr.Read()) {
+                    yield return rdr.RecordToExpando(); ;
+                }
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args) {

--- a/Massive.PostgreSQL.cs
+++ b/Massive.PostgreSQL.cs
@@ -238,7 +238,11 @@ namespace Massive.PostgreSQL
         {
             using (var conn = OpenConnection())
             {
-                return Query(sql,conn,args);
+                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+                while (rdr.Read())
+                {
+                    yield return rdr.RecordToExpando(); ;
+                }
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args)

--- a/Massive.Sqlite.cs
+++ b/Massive.Sqlite.cs
@@ -233,7 +233,11 @@ namespace Massive.SQLite
         {
             using (var conn = OpenConnection())
             {
-                return Query(sql, conn, args);
+                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+                while (rdr.Read())
+                {
+                    yield return rdr.RecordToExpando(); ;
+                }
             }
         }
       

--- a/Massive.cs
+++ b/Massive.cs
@@ -195,7 +195,10 @@ namespace Massive {
         /// </summary>
         public virtual IEnumerable<dynamic> Query(string sql, params object[] args) {
             using (var conn = OpenConnection()) {
-                return Query(sql, conn, args);
+                var rdr = CreateCommand(sql, conn, args).ExecuteReader();
+                while (rdr.Read()) {
+                    yield return rdr.RecordToExpando(); ;
+                }
             }
         }
         public virtual IEnumerable<dynamic> Query(string sql, DbConnection connection, params object[] args) {


### PR DESCRIPTION
Reverts FransBouma/Massive#221

It turns out this doesn't work. The problem is that the using() wrapping the call closes the connection before the enumerator runs. So this pull request has to be rolled back and the optimization can't be done.