### PR TITLE
Oracle: for paged results, missing parens in select query causes Table Not Found

### DIFF
--- a/src/Massive.Oracle.cs
+++ b/src/Massive.Oracle.cs
@@ -191,7 +191,7 @@ namespace Massive
 		/// </returns>
 		protected virtual string GetSelectQueryPattern(int limit, string whereClause, string orderByClause)
 		{
-			var normalQuery = string.Format("SELECT {{0}} FROM {{1}}{0}{1}", whereClause, orderByClause);
+			var normalQuery = string.Format("SELECT {{0}} FROM ({{1}}){0}{1}", whereClause, orderByClause);
 			if(limit > 0)
 			{
 				// we have to wrap the query and then apply the rownum filter, as aggregates etc. otherwise aren't going to contain the right values, as they're then applied to the

--- a/tests/Oracle/ReadWriteTests.cs
+++ b/tests/Oracle/ReadWriteTests.cs
@@ -101,6 +101,15 @@ namespace Massive.Tests.Oracle
 			Assert.AreEqual(60, page2.TotalRecords);
 		}
 
+        [Test]
+        public void Paged_SqlSpecification()
+        {
+            var depts = new Department();
+            var page2 = depts.Paged(sql: "SELECT * FROM DEPT", primaryKey: "DEPTNO", pageSize: 10, currentPage: 2);
+            var pageItems = ((IEnumerable<dynamic>)page2.Items).ToList();
+            Assert.AreEqual(10, pageItems.Count);
+            Assert.AreEqual(60, page2.TotalRecords);
+        }
 
 		[Test]
 		public void Insert_SingleRow()


### PR DESCRIPTION
Fixes issue that happens when feeding Paged() a full query via the `sql:` argument, which results in a Table Not Found error.
