### PR TITLE
Remove unnecessary @ on one occurrence of where variable name

### DIFF
--- a/src/Massive.Shared.cs
+++ b/src/Massive.Shared.cs
@@ -978,7 +978,7 @@ namespace Massive
 			var sql = string.Format(this.GetDeleteQueryPattern(), TableName);
 			if(key == null)
 			{
-				sql += ReadifyWhereClause(@where);
+				sql += ReadifyWhereClause(where);
 			}
 			else
 			{


### PR DESCRIPTION
Worthwhile but minor change.

The @ is allowed by unnecessary (it enables the use of keywords as underlying variable names). Also, the variable is not named this way in any other similar usage in the file.