### PR TITLE
Add args support to TryInvokeMember plus related tests

### DIFF
--- a/tests/SqlServer/ReadTests.cs
+++ b/tests/SqlServer/ReadTests.cs
@@ -22,19 +22,19 @@ namespace Massive.Tests
 
 
 		[Test]
-		public void MaxOnFilteredSet()
+		public void MaxOnFilteredSet_WhereSpecification()
 		{
 			var soh = new SalesOrderHeader();
-			var result = ((dynamic)soh).Max(columns: "SalesOrderID", where: "SalesOrderID<100000");
+			var result = ((dynamic)soh).Max(columns: "SalesOrderID", where: "SalesOrderID < @0", args: 100000);
 			Assert.AreEqual(75123, result);
 		}
 
 
 		[Test]
-		public void MaxOnFilteredSet2()
+		public void MaxOnFilteredSet_NamedArgument()
 		{
 			var soh = new SalesOrderHeader();
-			var result = ((dynamic)soh).Max(columns: "SalesOrderID", TerritoryID:10);
+			var result = ((dynamic)soh).Max(columns: "SalesOrderID", TerritoryID: 10);
 			Assert.AreEqual(75117, result);
 		}
 
@@ -189,6 +189,64 @@ namespace Massive.Tests
 				Assert.AreEqual(allRows[i].SalesOrderID, allRowsAsDataTable.Rows[i]["SalesOrderId"]);
 				Assert.AreEqual(30052, allRowsAsDataTable.Rows[i]["CustomerId"]);
 			}
+		}
+
+
+		[Test]
+		public void Single()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single();
+			Assert.IsNotNull(singleInstance);
+		}
+
+
+		[Test]
+		public void Single_PKSpecification()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single(43666);
+			Assert.AreEqual(43666, singleInstance.SalesOrderID);
+		}
+
+
+		[Test]
+		public void Single_PKSpecification_ColumnsSpecification()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single(43666, columns: "SalesOrderID as SOID, Status, SalesPersonID");
+			Assert.AreEqual(43666, singleInstance.SOID);
+			var siAsDict = (IDictionary<string, object>)singleInstance;
+			Assert.AreEqual(3, siAsDict.Count);
+		}
+
+
+		[Test]
+		public void Single_NoMatch()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single(-1);
+			Assert.IsNull(singleInstance);
+		}
+
+
+		[Test]
+		public void Single_WhereSpecification()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single(where: "SalesOrderID=@0", args: 43666);
+			Assert.AreEqual(43666, singleInstance.SalesOrderID);
+		}
+
+
+		[Test]
+		public void Single_WhereSpecification_ColumnsSpecification()
+		{
+			dynamic soh = new SalesOrderHeader();
+			var singleInstance = soh.Single(where: "SalesOrderID = @0", columns: "SalesOrderID as SOID, Status, SalesPersonID", args: 43666);
+			Assert.AreEqual(43666, singleInstance.SOID);
+			var siAsDict = (IDictionary<string, object>)singleInstance;
+			Assert.AreEqual(3, siAsDict.Count);
 		}
 
 


### PR DESCRIPTION
I was going to create a pull request which added `columns` support to the first of the two `Single(...)` methods in `Massive.Shared.cs` (the one which already allowed `where` and `args` as params), since the other `Single(...)` method has this.

But as I was preparing this for a potential pull request, I realised that I could add `args` support to `TryInvokeMember` instead. That gives dynamic support for the variant of `Single(..)` which I wanted (with all of `columns`, `where` and `args`), which I think is a reasonable thing to want. But it has the very positive side-effect of adding `args` support to all the other dynamic method calls which `TryInvokeMember` handles, as I've shown in a test (the slightly modified `MaxOnFilteredSet` test, which can now use `args` as it might naturally do).

The only downside here is that I have supported `args` in the `where` predicate by counting the number of `@` symbols in the string. Obviously this can be incorrect in unusual cases, as no genuine parsing is being done. But I think (hope you might agree...) that this suggested new feature:

- Fits the Massive philosophy of getting as much functionality out of simple code as possible, sometimes at the expense of gold-plated error testing, etc.
- Will be extremely useful in many cases
- Will very, very rarely break any existing code
- Is possible to work around (e.g. with a blank argument, or better, by generating the `@` character with SQL `CHAR(64)` in the case where an '@' with another meaning in the `where` clause is required).

In addition, I have added several new tests, which expose this feature. And a short `<remarks>` comment to the remaining explicit version of `Single(...)` so that someone reading the code and new to Massive might realise how to get at the many other variants of `Single(...)` which `TryInvokeMember` supports.