### PR TITLE
Removed Find_Alias... from test names

### DIFF
--- a/tests/SqlServer/ReadTests.cs
+++ b/tests/SqlServer/ReadTests.cs
@@ -213,7 +213,7 @@ namespace Massive.Tests
 
 
 		[Test]
-		public void Find_AliasGet_AllColumns()
+		public void Get_AllColumns()
 		{
 			dynamic soh = new SalesOrderHeader();
 			var singleInstance = soh.Get(SalesOrderID: 43666);
@@ -222,7 +222,7 @@ namespace Massive.Tests
 
 
 		[Test]
-		public void Find_AliasFirst_AllColumns()
+		public void First_AllColumns()
 		{
 			dynamic soh = new SalesOrderHeader();
 			var singleInstance = soh.First(SalesOrderID: 43666);
@@ -231,7 +231,7 @@ namespace Massive.Tests
 
 
 		[Test]
-		public void Find_AliasSingle_AllColumns()
+		public void Single_AllColumns()
 		{
 			dynamic soh = new SalesOrderHeader();
 			var singleInstance = soh.Single(SalesOrderID: 43666);


### PR DESCRIPTION
Three tests which dynamically invoke a method on `DynamicModel` (i.e. by implicitly invoking `TryInvokeMember`) were named `Find_Alias[MethodWord]...`, but all the other tests, including some which also operate via `TryInvokeMember`, are simply named `MethodWord...`.

So I'm suggesting that, without changing the tests at all, the above-proposed change to the test method names is more consistent across the entire test file, and therefore less confusing to someone coming to the code.

(As far as I can see, the implication of the pre-existing naming convention would be that `Find` is the primary dynamic method supported by `TryInvokeMember`, and that other ways of calling `TryInvokeMember` are aliases for this. But that seems to be just one way of thinking about the code, with no particular validity over and above treating any other dynamic method name, or none of them, as the 'primary' one.)