### PR TITLE
Add sp support

### DIFF
--- a/src/Massive.SP.cs
+++ b/src/Massive.SP.cs
@@ -1,0 +1,149 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////////////////
+// Massive v2.0. Additional stored procedure support
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Licensed to you under the New BSD License
+// http://www.opensource.org/licenses/bsd-license.php
+// Massive is copyright (c) 2009-2017 various contributors.
+// All rights reserved.
+// See for sourcecode, full history and contributors list: https://github.com/FransBouma/Massive
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted 
+// provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+//   following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and 
+//   the following disclaimer in the documentation and/or other materials provided with the distribution.
+// - The names of its contributors may not be used to endorse or promote products derived from this software 
+//   without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS 
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY 
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY 
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+using System;
+using System.Data;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Data.Common;
+using System.Dynamic;
+
+namespace Massive
+{
+	/// <summary>
+	/// Adds stored procedure return values, parameter names and directions to Massive
+	/// </summary>
+	public partial class DynamicModel
+	{
+		#region Constants
+		/// <summary>
+		/// Name for automatically added returnValue param
+		/// </summary>
+		private const string _returnValueParamName = "returnValue";
+		#endregion
+
+
+		/// <summary>
+		/// Execute stored procedure with optional directional params.
+		/// Does not process any result sets; for an SP with input params only, first result set may be read by using DynamicModel.Query instead.
+		/// For each set of params, you can pass in an Anonymous object, an ExpandoObject, a regular old POCO, or a NameValueCollection e.g. from a Request.Form or Request.QueryString.
+		/// </summary>
+		/// <param name="spName">Stored procedure name</param>
+		/// <param name="inParams">Input params (optional). Names and values are used.</param>
+		/// <param name="outParams">Output params (optional). Names are used. Values are used to determine param type.</param>
+		/// <param name="ioParams">Input-output params (optional). Names and values are used.</param>
+		/// <param name="result">Dynamic holding 'returnValue' plus output values of any output and input-output params</param>
+		public virtual dynamic ExecuteSP(string spName, object inParams = null, object outParams = null, object ioParams = null)
+		{
+			var iAsExpando = inParams.ToExpando();
+			var oAsExpando = outParams.ToExpando();
+			var ioAsExpando = ioParams.ToExpando();
+			using(var conn = OpenConnection())
+			{
+				var result = PerformExecuteSP(conn, null, spName, iAsExpando, oAsExpando, ioAsExpando);
+				conn.Close();
+				return result;
+			}
+		}
+
+
+		/// <summary>
+		/// Executes stored procedure, with optional directional params from dynamics
+		/// </summary>
+		/// <param name="connectionToUse">The connection to use, has to be open.</param>
+		/// <param name="transactionToUse">The transaction to use, can be null.</param>
+		/// <param name="spName">Stored procedure name</param>
+		/// <param name="inParams">Dynamic containing input params</param>
+		/// <param name="outParams">Dynamic containing output params</param>
+		/// <param name="ioParams">Dynamic containing input-output params</param>
+		/// <param name="result">Dynamic holding 'returnValue' plus output values of output and input-output params</param>
+		private dynamic PerformExecuteSP(DbConnection connectionToUse, DbTransaction transactionToUse, string spName, dynamic inParams, dynamic outParams, dynamic ioParams)
+		{
+			DbCommand cmd = CreateSPCommand(spName, inParams, outParams, ioParams);
+			cmd.Connection = connectionToUse;
+			cmd.Transaction = transactionToUse;
+			dynamic result = new ExpandoObject();
+			cmd.ExecuteNonQuery(); // return value of this call not worth returning to user, as per documentation always returns -1 when called on SP
+			var dictionary = (IDictionary<string, object>)result;
+			foreach(var item in (IDictionary<string, object>)outParams)
+			{
+				AddParamToExpando(cmd, item.Key, dictionary);
+			}
+			foreach(var item in (IDictionary<string, object>)ioParams)
+			{
+				AddParamToExpando(cmd, item.Key, dictionary);
+			}
+			AddParamToExpando(cmd, _returnValueParamName, dictionary, _returnValueParamName);
+			return result;
+		}
+
+
+		/// <summary>
+		/// Help put results of SP call into ExpandoObject
+		/// </summary>
+		/// <param name="cmd">Completed SP command</param>
+		/// <param name="name">Unescaped SP param name</param>
+		/// <param name="dictionary">Target dictionary</param>
+		/// <param name="storeAs">Override default name</param>
+		private void AddParamToExpando(DbCommand cmd, string name, IDictionary<string, object> dictionary, string storeAs = null)
+		{
+			object value = cmd.Parameters["@" + name].Value;
+			dictionary.Add(storeAs ?? name, value == DBNull.Value ? null : value);
+		}
+
+
+		/// <summary>
+		/// Creates DbCommand to execute stored procedure, with optional directional params from dynamics
+		/// </summary>
+		/// <param name="spName">Stored procedure name</param>
+		/// <param name="inParams">Dynamic containing input params</param>
+		/// <param name="outParams">Dynamic containing output params</param>
+		/// <param name="ioParams">Dynamic containing input-output params</param>
+		/// <returns>Ready to use DbCommand</returns>
+		public virtual DbCommand CreateSPCommand(string spName, dynamic inParams = null, dynamic outParams = null, dynamic ioParams = null)
+		{
+			var cmd = CreateCommand(spName, null);
+			cmd.CommandType = CommandType.StoredProcedure;
+			foreach(var item in (IDictionary<string, object>)inParams)
+			{
+				cmd.AddParam(item.Value, item.Key);
+			}
+			foreach(var item in (IDictionary<string, object>)outParams)
+			{
+				cmd.AddParam(item.Value, item.Key, ParameterDirection.Output);
+			}
+			foreach(var item in (IDictionary<string, object>)ioParams)
+			{
+				cmd.AddParam(item.Value, item.Key, ParameterDirection.InputOutput);
+			}
+			cmd.AddParam(0, _returnValueParamName, ParameterDirection.ReturnValue);
+			return cmd;
+		}
+	}
+}

--- a/src/Massive.Shared.cs
+++ b/src/Massive.Shared.cs
@@ -108,6 +108,10 @@ namespace Massive
 				return o;
 			}
 			var result = new ExpandoObject();
+			if (o == null)
+			{
+				return result;
+			}
 			var d = (IDictionary<string, object>)result; //work with the Expando as a Dictionary
 			if(o.GetType() == typeof(NameValueCollection) || o.GetType().IsSubclassOf(typeof(NameValueCollection)))
 			{

--- a/src/Massive.SqlServer.cs
+++ b/src/Massive.SqlServer.cs
@@ -44,10 +44,13 @@ namespace Massive
 		/// </summary>
 		/// <param name="cmd">The command to add the parameter to.</param>
 		/// <param name="value">The value to add as a parameter to the command.</param>
-		public static void AddParam(this DbCommand cmd, object value)
+		/// <param name="name">The parameter name (optional).</param>
+		/// <param name="direction">The parameter direction (optional).</param>
+		public static void AddParam(this DbCommand cmd, object value, string name = null, System.Data.ParameterDirection direction = System.Data.ParameterDirection.Input)
 		{
 			var p = cmd.CreateParameter();
-			p.ParameterName = string.Format("@{0}", cmd.Parameters.Count);
+			p.ParameterName = string.Format("@{0}", name ?? cmd.Parameters.Count.ToString());
+			p.Direction = direction;
 			if(value == null)
 			{
 				p.Value = DBNull.Value;

--- a/src/Massive.SqlServer.csproj
+++ b/src/Massive.SqlServer.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Massive.Shared.Async.cs" />
     <Compile Include="Massive.Shared.cs" />
     <Compile Include="Massive.SqlServer.cs" />
+    <Compile Include="Massive.SP.cs" />
     <Compile Include="Properties\SharedAssemblyInfo.cs" />
     <Compile Include="Properties\SqlServerAssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/SqlServer/App.config
+++ b/tests/SqlServer/App.config
@@ -7,5 +7,6 @@
 		-->
 		<add name="AdventureWorks.ConnectionString.SQL Server (SqlClient)" connectionString="data source=thor.sd.local;initial catalog=AdventureWorks;integrated security=SSPI;persist security info=False;packet size=4096" providerName="System.Data.SqlClient"/>
 		<add name="MassiveWriteTests.ConnectionString.SQL Server (SqlClient)" connectionString="data source=thor.sd.local;initial catalog=MassiveWriteTests;integrated security=SSPI;persist security info=False;packet size=4096" providerName="System.Data.SqlClient"/>
+		<add name="MassiveSPTests.ConnectionString.SQL Server (SqlClient)" connectionString="data source=thor.sd.local;initial catalog=MassiveSPTests;integrated security=SSPI;persist security info=False;packet size=4096" providerName="System.Data.SqlClient"/>
 	</connectionStrings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/tests/SqlServer/ConstantsEnums.cs
+++ b/tests/SqlServer/ConstantsEnums.cs
@@ -9,5 +9,6 @@ namespace Massive.Tests
 	{
 		public static readonly string ReadTestConnectionStringName = "AdventureWorks.ConnectionString.SQL Server (SqlClient)";
 		public static readonly string WriteTestConnectionStringName = "MassiveWriteTests.ConnectionString.SQL Server (SqlClient)";
+		public static readonly string SPTestConnectionStringName = "MassiveSPTests.ConnectionString.SQL Server (SqlClient)";
 	}
 }

--- a/tests/SqlServer/Massive.Tests.SqlServer.csproj
+++ b/tests/SqlServer/Massive.Tests.SqlServer.csproj
@@ -87,10 +87,14 @@
     <Compile Include="..\..\src\Massive.SqlServer.cs">
       <Link>Massive.SqlServer.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Massive.SP.cs">
+      <Link>Massive.SP.cs</Link>
+    </Compile>
     <Compile Include="ConstantsEnums.cs" />
     <Compile Include="AsyncReadTests.cs" />
     <Compile Include="WriteTests.cs" />
     <Compile Include="ReadTests.cs" />
+    <Compile Include="SPTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TableClasses\Product.cs" />
     <Compile Include="TableClasses\Category.cs" />

--- a/tests/SqlServer/SPTestDB_Create.sql
+++ b/tests/SqlServer/SPTestDB_Create.sql
@@ -1,0 +1,44 @@
+USE master
+GO
+CREATE DATABASE [MassiveSPTests] /* ON PRIMARY (NAME=MassiveSPTests_dat, FILENAME='c:\mycatalogs\MassiveSPTests.mdf', SIZE=10MB) */
+GO
+
+USE [MassiveSPTests]
+GO
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- Stored procedures
+-- ----------------------------------------------------------------------------------------------------------------
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE PROCEDURE [dbo].[pr_Plus]
+	@FirstArg INT = 0,
+	@SecondArg INT = 0
+AS
+	RETURN @FirstArg + @SecondArg
+GO
+
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE PROCEDURE [dbo].[pr_Test]
+	@MyInteger INT,
+	@OneString VARCHAR(MAX) OUTPUT,
+	@AnotherString VARCHAR(MAX) OUTPUT,
+	@ThisDate DATETIME OUTPUT
+AS
+	SET @MyInteger = @MyInteger + 1
+
+	SET @OneString = 'The result is ' + CAST(@MyInteger AS VARCHAR(MAX))
+	SET @AnotherString = 'The input string was ''' + ISNULL(@AnotherString, '<null>') + ''''
+	SET @ThisDate = GETDATE()
+
+	RETURN @MyInteger
+GO

--- a/tests/SqlServer/SPTests.cs
+++ b/tests/SqlServer/SPTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Massive.Tests.TableClasses;
+using NUnit.Framework;
+using SD.Tools.OrmProfiler.Interceptor;
+
+namespace Massive.Tests
+{
+	[TestFixture]
+	public class SPTests
+	{
+		[TestFixtureSetUp]
+		public void Setup()
+		{
+			InterceptorCore.Initialize("Massive SqlServer stored procedure tests .NET 4.0");
+		}
+
+
+		[Test]
+		public void SP_ReturnValue()
+		{
+			var db = new DynamicModel(TestConstants.SPTestConnectionStringName);
+			var result = db.ExecuteSP("pr_Plus");
+			Assert.AreEqual(result.returnValue, 0);
+		}
+
+
+		[Test]
+		public void SP_NamedParams()
+		{
+			var db = new DynamicModel(TestConstants.SPTestConnectionStringName);
+			var result = db.ExecuteSP("pr_Plus", new { FirstArg = 1, SecondArg = 5 });
+			Assert.AreEqual(result.returnValue, 6);
+		}
+
+
+		[Test]
+		/// <remarks>
+		/// The type of each param must be implicitly specified by a value, even for output params (if the input object contains
+		/// a typed field with value of null the type will be ignored - this is the same behaviour as in other parts of Massive).
+		/// </remarks>
+		public void SP_ParamDirections()
+		{
+			var db = new DynamicModel(TestConstants.SPTestConnectionStringName);
+			var result = db.ExecuteSP("pr_Test",
+									  inParams: new { MyInteger = 4 },
+									  outParams: new { OneString = "", ThisDate = DateTime.Now },
+									  ioParams: new { AnotherString = "hello" });
+			Assert.AreEqual(5, result.returnValue);
+			Assert.AreEqual("The result is 5", result.OneString);
+			Assert.AreEqual(DateTime.Now.Date, result.ThisDate.Date);
+			Assert.AreEqual("The input string was 'hello'", result.AnotherString);
+		}
+	}
+}

--- a/tests/SqlServer/SPTests.cs
+++ b/tests/SqlServer/SPTests.cs
@@ -37,8 +37,8 @@ namespace Massive.Tests
 
 		[Test]
 		/// <remarks>
-		/// The type of each param must be implicitly specified by a value, even for output params (if the input object contains
-		/// a typed field with value of null the type will be ignored - this is the same behaviour as in other parts of Massive).
+		/// The type of each param must be implicitly specified by a value, even for output params (if any xParams object contains a
+		/// typed field with a null value the type of the field is not used - this is the same behaviour as in other parts of Massive).
 		/// </remarks>
 		public void SP_ParamDirections()
 		{

--- a/tests/SqlServer/WriteTests.cs
+++ b/tests/SqlServer/WriteTests.cs
@@ -145,16 +145,8 @@ namespace Massive.Tests
 		[TestFixtureTearDown]
 		public void CleanUp()
 		{
-			// no way to call a proc easily at the moment, which should change in the future. 
 			var db = new DynamicModel(TestConstants.WriteTestConnectionStringName);
-			using(var conn = db.OpenConnection())
-			{
-				var cmd = conn.CreateCommand();
-				cmd.CommandText = "dbo.pr_clearAll";
-				cmd.CommandType = CommandType.StoredProcedure;
-				cmd.ExecuteNonQuery();
-				conn.Close();
-			}
+			db.ExecuteSP("pr_clearAll");
 		}
 	}
 }


### PR DESCRIPTION
I have added support for stored procedure return values, paramater names and parameter directions to Massive.

I have worked hard to make the code look and feel Massive style - lightweight, very good 'bang for buck' (high functionality for few lines of simple code).

I do fully realise that existing Massive already supports reading a single result set from a stored procedure with numbered parameters. This new code does not support reading any result sets (which is still supported in the old way via `Query(...)` #67). But it does very neatly and cleanly support the new features mentioned above.

The file `Massive.SP.cs` is optional (i.e. Massive works fine without it, similar to `Massive.Shared.Async.cs`). It required some very small, non-breaking changes to other files (`Massive.Shared.cs` and `Massive.SqlServer.cs`). It only supports SQL Server at the moment (but does not break support for anything else).

I have included a (very small) test DB definition and tests against it, which also of course serves to demonstrate the calling syntax.