### PR TITLE
Update target framework to v4.8 for all projects

### DIFF
--- a/src/Massive.MySql.csproj
+++ b/src/Massive.MySql.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.MySql</RootNamespace>
     <AssemblyName>Massive.MySql</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Massive.Oracle.csproj
+++ b/src/Massive.Oracle.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Oracle</RootNamespace>
     <AssemblyName>Massive.Oracle</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Massive.PostgreSql.csproj
+++ b/src/Massive.PostgreSql.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.PostgreSql</RootNamespace>
     <AssemblyName>Massive.PostgreSql</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Massive.SqlServer.csproj
+++ b/src/Massive.SqlServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.SqlServer</RootNamespace>
     <AssemblyName>Massive.SqlServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Massive.Sqlite.csproj
+++ b/src/Massive.Sqlite.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Sqlite</RootNamespace>
     <AssemblyName>Massive.Sqlite</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
This commit updates the target framework version from v4.5 to v4.8 for the following projects: Massive.MySql, Massive.Oracle, Massive.PostgreSql, Massive.SqlServer, and Massive.Sqlite. Additionally, an extraneous line has been removed from the Massive.Sqlite.csproj file to correct a formatting issue.