### PR TITLE
Update test solution to .NET Framework 4.8

### DIFF
--- a/tests/MySql/App.config
+++ b/tests/MySql/App.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<connectionStrings>
 		<!-- Important: attempts to execute stored procedures against the database fail unless the database name is all lower case (affects Oracle/MySQL driver but not Devart driver) -->
-		<add name="Sakila.ConnectionString.MySql (MySql.Data.MySqlClient)" connectionString="data source=localhost;database=sakila;user id=Massive;password=mt123;persist security info=false;"  providerName="MySql.Data.MySqlClient"/>
-		<add name="MassiveWriteTests.ConnectionString.MySql (MySql.Data.MySqlClient)" connectionString="data source=localhost;database=massivewritetests;user id=Massive;password=mt123;persist security info=false;"  providerName="MySql.Data.MySqlClient"/>
+		<add name="Sakila.ConnectionString.MySql (MySql.Data.MySqlClient)" connectionString="data source=localhost;database=sakila;user id=Massive;password=mt123;persist security info=false;" providerName="MySql.Data.MySqlClient"/>
+		<add name="MassiveWriteTests.ConnectionString.MySql (MySql.Data.MySqlClient)" connectionString="data source=localhost;database=massivewritetests;user id=Massive;password=mt123;persist security info=false;" providerName="MySql.Data.MySqlClient"/>
 		
-		<add name="Sakila.ConnectionString.MySql (Devart.Data.MySql)" connectionString="data source=localhost;database=Sakila;user id=Massive;password=mt123;persist security info=false;"  providerName="Devart.Data.MySql"/>
-		<add name="MassiveWriteTests.ConnectionString.MySql (Devart.Data.MySql)" connectionString="data source=localhost;database=MassiveWriteTests;user id=Massive;password=mt123;persist security info=false;"  providerName="Devart.Data.MySql"/>
+		<add name="Sakila.ConnectionString.MySql (Devart.Data.MySql)" connectionString="data source=localhost;database=Sakila;user id=Massive;password=mt123;persist security info=false;" providerName="Devart.Data.MySql"/>
+		<add name="MassiveWriteTests.ConnectionString.MySql (Devart.Data.MySql)" connectionString="data source=localhost;database=MassiveWriteTests;user id=Massive;password=mt123;persist security info=false;" providerName="Devart.Data.MySql"/>
 	</connectionStrings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/MySql/Massive.Tests.MySql.csproj
+++ b/tests/MySql/Massive.Tests.MySql.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Tests.MySql</RootNamespace>
     <AssemblyName>Massive.Tests.MySql</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Oracle/App.config
+++ b/tests/Oracle/App.config
@@ -1,13 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<connectionStrings>
 		<!--
 			 Please adjust the connection string embedded in the elements below to target the proper catalog / server using the proper user / password combination
 			 If you use a differently named adventure works database, be sure to change the initial catalog descriptions in the connection strings below.
 		-->
-		<add name="Scott.ConnectionString.Oracle (Oracle.ManagedDataAccess.Client)" connectionString="data source=oravirtualnerd;user id=SCOTT;password=TIGER;persist security info=false;"
-			 providerName="Oracle.ManagedDataAccess.Client"/>
-		<add name="Scott.ConnectionString.Oracle (Oracle.DataAccess.Client)" connectionString="data source=oravirtualnerd;user id=SCOTT;password=TIGER;persist security info=false;"
-			 providerName="Oracle.DataAccess.Client"/>
+		<add name="Scott.ConnectionString.Oracle (Oracle.ManagedDataAccess.Client)" connectionString="data source=oravirtualnerd;user id=SCOTT;password=TIGER;persist security info=false;" providerName="Oracle.ManagedDataAccess.Client"/>
+		<add name="Scott.ConnectionString.Oracle (Oracle.DataAccess.Client)" connectionString="data source=oravirtualnerd;user id=SCOTT;password=TIGER;persist security info=false;" providerName="Oracle.DataAccess.Client"/>
 	</connectionStrings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/Oracle/Massive.Tests.Oracle.csproj
+++ b/tests/Oracle/Massive.Tests.Oracle.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Tests.Oracle</RootNamespace>
     <AssemblyName>Massive.Tests.Oracle</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +41,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -47,6 +51,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">

--- a/tests/PostgreSql/App.config
+++ b/tests/PostgreSql/App.config
@@ -1,11 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<connectionStrings>
 		<!--
 			 Please adjust the connection string embedded in the element below to target the proper catalog / server using the proper user / password combination
 			 If you use a differently named adventure works database, be sure to change the initial catalog descriptions in the connection strings below.
 		-->
-		<add name="Northwind.ConnectionString.PostgreSql (Npgsql)" connectionString="Database=Northwind;Server=windows2008r2.sd.local;Port=5432;User Id=postgres;Password=123;" 
-			 providerName="Npgsql"/>
+		<add name="Northwind.ConnectionString.PostgreSql (Npgsql)" connectionString="Database=Northwind;Server=windows2008r2.sd.local;Port=5432;User Id=postgres;Password=123;" providerName="Npgsql"/>
 	</connectionStrings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/PostgreSql/Massive.Tests.PostgreSql.csproj
+++ b/tests/PostgreSql/Massive.Tests.PostgreSql.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PostgreSql</RootNamespace>
     <AssemblyName>PostgreSql</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +41,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -47,6 +51,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/tests/SqlServer/App.config
+++ b/tests/SqlServer/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<connectionStrings>
 		<!--
@@ -8,4 +8,4 @@
 		<add name="AdventureWorks.ConnectionString.SQL Server (SqlClient)" connectionString="data source=thor.sd.local;initial catalog=AdventureWorks;integrated security=SSPI;persist security info=False;packet size=4096" providerName="System.Data.SqlClient"/>
 		<add name="MassiveWriteTests.ConnectionString.SQL Server (SqlClient)" connectionString="data source=thor.sd.local;initial catalog=MassiveWriteTests;integrated security=SSPI;persist security info=False;packet size=4096" providerName="System.Data.SqlClient"/>
 	</connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/SqlServer/Massive.Tests.SqlServer.csproj
+++ b/tests/SqlServer/Massive.Tests.SqlServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Tests</RootNamespace>
     <AssemblyName>Massive.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/tests/Sqlite/App.config
+++ b/tests/Sqlite/App.config
@@ -1,17 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
     <!--
 			 Please adjust the connection string embedded in the element below to target the proper catalog / server using the proper user / password combination
 			 If you use a differently named adventure works database, be sure to change the initial catalog descriptions in the connection strings below.
 		-->
-    <add name="ReadWriteTests.ConnectionString.SQLite" connectionString="Data Source=C:\Users\frans\Documents\ChinookDatabase1.4_Sqlite\Chinook_Sqlite_AutoIncrementPKs.sqlite;Version=3;" providerName="System.Data.SQLite" />
+    <add name="ReadWriteTests.ConnectionString.SQLite" connectionString="Data Source=C:\Users\frans\Documents\ChinookDatabase1.4_Sqlite\Chinook_Sqlite_AutoIncrementPKs.sqlite;Version=3;" providerName="System.Data.SQLite"/>
   </connectionStrings>
 	<system.data>
 		<DbProviderFactories>
-			<remove invariant="System.Data.SQLite" />
-			<add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite"
-                 type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite, Version=1.0.98.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139" />
+			<remove invariant="System.Data.SQLite"/>
+			<add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite, Version=1.0.98.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
 		</DbProviderFactories>
 	</system.data>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/Sqlite/Massive.Tests.Sqlite.csproj
+++ b/tests/Sqlite/Massive.Tests.Sqlite.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Massive.Tests.Sqlite</RootNamespace>
     <AssemblyName>Massive.Tests.Sqlite</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>1af09f97</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Sqlite/packages.config
+++ b/tests/Sqlite/packages.config
@@ -4,5 +4,5 @@
   <package id="SD.Tools.Algorithmia" version="1.1.0" targetFramework="net45" />
   <package id="SD.Tools.BCLExtensions" version="1.0.0" targetFramework="net45" />
   <package id="SD.Tools.OrmProfiler.Interceptor.NET45" version="1.5.20150715" targetFramework="net45" />
-  <package id="System.Data.SQLite.Core" version="1.0.98.1" targetFramework="net45" />
+  <package id="System.Data.SQLite.Core" version="1.0.98.1" targetFramework="net45" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
This pull request updates the test projects across multiple database platforms to target .NET Framework 4.8 and includes minor configuration file adjustments for consistency and compatibility. The most important changes involve upgrading the target framework versions, adding runtime support, and ensuring proper compatibility settings.

### Framework and Runtime Updates:
* Updated `TargetFrameworkVersion` in project files for MySQL, Oracle, PostgreSQL, SQL Server, and SQLite tests to `.NETFramework,Version=v4.8`. Added `<TargetFrameworkProfile />` and `<Prefer32Bit>false` settings for compatibility. (`tests/MySql/Massive.Tests.MySql.csproj` [[1]](diffhunk://#diff-d636519e75021a3f1abef6e931792ffef106a8995dbf37b6868cd2a1c01ece44L12-R14) `tests/Oracle/Massive.Tests.Oracle.csproj` [[2]](diffhunk://#diff-383171d4623987f04750e6b91773642e316b8a76e54b10277a705a7d4edf05f2L12-R14) `tests/PostgreSql/Massive.Tests.PostgreSql.csproj` [[3]](diffhunk://#diff-0821c143e6eeca509345111c8a56ef61c3e12a65684258e036b4390b3dedc47dL12-R14) `tests/SqlServer/Massive.Tests.SqlServer.csproj` [[4]](diffhunk://#diff-11f6b85279051b18c39c13a85d2cb9c51d42b6f42e2422a81331767a9bf41ff0L12-R12) `tests/Sqlite/Massive.Tests.Sqlite.csproj` [[5]](diffhunk://#diff-6e45fe520787548d0a59363b181e15c8001da2e2a70c68f30171c49c66b53bf6L12-R15)

### Configuration File Adjustments:
* Added `<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>` to `App.config` files for MySQL, Oracle, PostgreSQL, SQL Server, and SQLite tests to specify runtime support. (`tests/MySql/App.config` [[1]](diffhunk://#diff-92413ff6a0f43849b90bfba9bd1efc650b4072c11cd6d628956fabada85e67d0L11-R11) `tests/Oracle/App.config` [[2]](diffhunk://#diff-75ec980eac4152a45a4653a7b0af520bef7df3d94dc8bc7fe42af0db014a7cd2L1-R11) `tests/PostgreSql/App.config` [[3]](diffhunk://#diff-a0a8413d4ae4da667b8448ae34beb375fbc1a197d10cb3b5757da0ec416d1109L1-R10) `tests/SqlServer/App.config` [[4]](diffhunk://#diff-cf29f63c04ebd3cfd9bc47af496a3636e5eafd8337898754c6a31d7065f2b32fL11-R11) `tests/Sqlite/App.config` [[5]](diffhunk://#diff-166445d62a0ae41a3eb4b5a3200eb774b1528148cec511b9120a9fbadb5e7798L13-R16)

### Minor Formatting Improvements:
* Removed unnecessary spaces and ensured consistent formatting in `App.config` files for all database test projects. (`tests/MySql/App.config` [[1]](diffhunk://#diff-92413ff6a0f43849b90bfba9bd1efc650b4072c11cd6d628956fabada85e67d0L1-R1) `tests/Oracle/App.config` [[2]](diffhunk://#diff-75ec980eac4152a45a4653a7b0af520bef7df3d94dc8bc7fe42af0db014a7cd2L1-R11) `tests/PostgreSql/App.config` [[3]](diffhunk://#diff-a0a8413d4ae4da667b8448ae34beb375fbc1a197d10cb3b5757da0ec416d1109L1-R10) `tests/SqlServer/App.config` [[4]](diffhunk://#diff-cf29f63c04ebd3cfd9bc47af496a3636e5eafd8337898754c6a31d7065f2b32fL1-R1) `tests/Sqlite/App.config` [[5]](diffhunk://#diff-166445d62a0ae41a3eb4b5a3200eb774b1528148cec511b9120a9fbadb5e7798L1-R1)

### SQLite-Specific Package Update:
* Marked the `System.Data.SQLite.Core` package in `packages.config` for SQLite tests as requiring reinstallation for compatibility with the updated framework. (`tests/Sqlite/packages.config` [tests/Sqlite/packages.configL7-R7](diffhunk://#diff-26bbdafe4ed4cfe9db9f58bbf18441fce7a64623f92ae38e0cda999ca0c4cbe5L7-R7))